### PR TITLE
fix: remove badge dimension constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/iterm.ts
+++ b/src/iterm.ts
@@ -330,12 +330,6 @@ export function writePaneProfile(
       "Alpha Component": opts?.badgeColor?.a ?? 0.85,
       "Color Space": "sRGB",
     },
-    // Constrain badge size — iTerm2's default is 50% width / 20% height
-    // which is too large. These are point limits, not percentages.
-    "Badge Max Width": 200,
-    "Badge Max Height": 40,
-    "Badge Right Margin": 10,
-    "Badge Top Margin": 10,
   };
 
   const profile = { Profiles: [profileEntry] };


### PR DESCRIPTION
## Summary
- Remove `Badge Max Width`, `Badge Max Height`, `Badge Right Margin`, `Badge Top Margin` from `writePaneProfile`
- These point-based overrides made multi-line badges (3-line convention) fill half the pane
- Panes without constraints (e.g. paris) already look correct using iTerm2's proportional defaults

## Verification
- [x] Compared paris (no constraints, correct size) vs everest (200×40, oversized)
- [x] Updated all live dynamic profiles to remove constraints
- [x] Brioche's 2-line badge on paris confirmed as the correct look

🤖 Generated with [Claude Code](https://claude.com/claude-code)