### PR TITLE
fix: pane_create uses target tab, not caller's pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -587,22 +587,36 @@ export class Orchestrator {
       await new Promise((r) => setTimeout(r, 300));
     }
 
-    // Split relative to a named pane, raw session ID, tab's session, or fall back to current.
+    // Split relative to: explicit pane/session → tab's session → any pane in the tab.
+    // Never fall back to the caller's pane — that's always wrong for cross-tab creates.
     let sessionId: string;
-    const splitTarget = relativeTo ?? tabRow?.iterm_session_id;
-    if (splitTarget) {
-      const resolvedId = relativeTo ? this.resolveSession(relativeTo) : splitTarget;
-      const alive = await this.terminal.isSessionAlive(resolvedId);
-      if (!alive) {
-        throw new Error(
-          `cannot split relative to '${relativeTo ?? tab}': terminal session ${resolvedId} is dead or stale. ` +
-          `Re-register the pane or tab, or omit relative_to to split the caller's pane.`
-        );
+    let splitTarget = relativeTo ?? tabRow?.iterm_session_id;
+
+    // If the tab has no session ID, find any existing pane in the tab to split from
+    if (!splitTarget) {
+      const tabPanes = this.store.listPanes(tab);
+      const paneWithSession = tabPanes.find((p) => p.iterm_id);
+      if (paneWithSession) {
+        splitTarget = paneWithSession.iterm_id!;
       }
-      sessionId = await this.terminal.splitSessionWithProfile(resolvedId, direction, profileName);
-    } else {
-      sessionId = await this.terminal.splitPaneWithProfile(direction, profileName);
     }
+
+    if (!splitTarget) {
+      throw new Error(
+        `tab '${tab}' has no terminal session and no panes with sessions. ` +
+        `The tab may need to be re-created, or specify relative_to with a pane name.`
+      );
+    }
+
+    const resolvedId = relativeTo ? this.resolveSession(relativeTo) : splitTarget;
+    const alive = await this.terminal.isSessionAlive(resolvedId);
+    if (!alive) {
+      throw new Error(
+        `cannot split relative to '${relativeTo ?? tab}': terminal session ${resolvedId} is dead or stale. ` +
+        `Re-register the pane or tab, or specify a different relative_to.`
+      );
+    }
+    sessionId = await this.terminal.splitSessionWithProfile(resolvedId, direction, profileName);
 
     const pane = this.store.createPane(paneName, tab, position, tabRow?.theme ?? undefined);
     this.store.setPaneItermId(paneName, sessionId);


### PR DESCRIPTION
## Summary
- `createPane` fell through to `splitPaneWithProfile` (splits caller's current pane) when the target tab had no `iterm_session_id`
- Older tabs (agiterra, fabrica, brioche, herald) all have empty session IDs
- Now falls back to any existing pane's session in the target tab
- If no session exists, errors clearly instead of silently splitting the wrong pane

## Root cause
`splitPaneWithProfile` uses iTerm2's `current session of current tab of current window` — always the caller. `splitSessionWithProfile` targets a specific session by ID. The fallback path chose the wrong one.

## Test plan
- [x] Confirmed 4 tabs in live DB have empty `iterm_session_id`
- [x] Code review: fallback chain is now `relativeTo → tab session → first pane session → error`
- [ ] Manual test: create pane on a tab with empty session ID but existing panes

Fixes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)