### PR TITLE
feat!: canonical AGENT_ID env var — v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "0.19.0",
+  "version": "1.0.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -26,7 +26,7 @@ export async function startServer(): Promise<void> {
   const orchestrator = new Orchestrator(terminal);
   const terminalName = terminal.name;
   const CALLER_AGENT_ID =
-    process.env.CREW_AGENT_ID ?? process.env.WIRE_AGENT_ID ?? "unknown";
+    process.env.AGENT_ID ?? "unknown";
   const ccSessionId = getClaudeCodeSessionId();
 
   /**

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -88,7 +88,7 @@ export class Orchestrator {
 
     // Set crew-specific identity + key vars
     const keyExport = opts.privateKeyB64 ? ` CREW_PRIVATE_KEY=${shellEscape(opts.privateKeyB64)}` : "";
-    const envExports = `export CREW_AGENT_ID=${shellEscape(opts.id)} CREW_AGENT_NAME=${shellEscape(opts.displayName)} WIRE_URL=${shellEscape(wireUrl)}${keyExport}`;
+    const envExports = `export AGENT_ID=${shellEscape(opts.id)} AGENT_NAME=${shellEscape(opts.displayName)} WIRE_URL=${shellEscape(wireUrl)}${keyExport}`;
     const fullCommand = `cd ${shellEscape(projectDir)} && ${envExports} && ${command}`;
 
     // Create screen session


### PR DESCRIPTION
## Summary
- Replace `CREW_AGENT_ID`/`WIRE_AGENT_ID`/`CREW_AGENT_NAME`/`WIRE_AGENT_NAME` with canonical `AGENT_ID`/`AGENT_NAME`
- Major version bump to 1.0.0

## Breaking change
All env var references to `CREW_AGENT_ID`, `WIRE_AGENT_ID`, `CREW_AGENT_NAME`, `WIRE_AGENT_NAME` are replaced with `AGENT_ID` and `AGENT_NAME`. Agent `.env` files and crew launch scripts must be updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)