### PR TITLE
fix: auto-detect CC session ID in agent_register

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -120,7 +120,7 @@ export async function startServer(): Promise<void> {
           id: { type: "string", description: "Agent ID (your Wire agent name)" },
           name: { type: "string", description: "Display name" },
           runtime: { type: "string", description: "Runtime: claude-code, codex, etc. Default: claude-code" },
-          cc_session_id: { type: "string", description: "Claude Code session ID. Auto-detected from CLAUDE_CODE_SESSION_ID if omitted." },
+          cc_session_id: { type: "string", description: "Claude Code session ID. Auto-detected from ~/.claude/sessions/ if omitted." },
         },
         required: ["id", "name"],
       },
@@ -412,7 +412,7 @@ export async function startServer(): Promise<void> {
             displayName: a.name as string,
             runtime: a.runtime as string | undefined,
             callerSessionId: await callerSession(),
-            ccSessionId: a.cc_session_id as string | undefined,
+            ccSessionId: (a.cc_session_id as string | undefined) ?? ccSessionId ?? undefined,
           });
           break;
         case "agent_badge":


### PR DESCRIPTION
## Summary
- `agent_register` now falls back to `getClaudeCodeSessionId()` when `cc_session_id` is not provided
- Reads CC session ID from `~/.claude/sessions/<PPID>.json` — deterministic, no env vars needed
- `agent_list` will now show `cc_session_id` for all agents, enabling `agent_stop` disambiguation during handoff

## How it works
MCP servers are direct children of the CC process. `process.ppid` → `~/.claude/sessions/<PID>.json` → `sessionId`. The session ID is stable across CC process restarts.

## Test plan
- [x] Verified `~/.claude/sessions/31787.json` contains `sessionId: 903d611e-...`
- [x] Verified process tree: MCP server ppid = CC process PID
- [x] Compilation verified
- [ ] Manual: after /reload-plugins, run agent_register and check agent_list shows cc_session_id

Fixes #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)