### PR TITLE
feat: iTerm2 flash + notify via OSC escape sequences

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/iterm-backend.ts
+++ b/src/iterm-backend.ts
@@ -87,13 +87,15 @@ export class ItermBackend implements TerminalBackend {
     return iterm.splitSessionWithProfile(sessionId, direction, profileName);
   }
 
-  async flashSession(_sessionId: string): Promise<void> {
-    // iTerm2 has no tab flash/notification ring equivalent
+  async flashSession(sessionId: string): Promise<void> {
+    // Bounce the dock icon via OSC 1337 RequestAttention
+    await iterm.writeEscapeToSession(sessionId, "\x1b]1337;RequestAttention=fireworks\x07");
   }
 
-  async notifySession(sessionId: string, title: string, _body?: string): Promise<void> {
-    // Fall back to setting badge text with the title
-    return iterm.setBadge(sessionId, title);
+  async notifySession(sessionId: string, title: string, body?: string): Promise<void> {
+    // macOS notification banner via OSC 9
+    const msg = body ? `${title}: ${body}` : title;
+    await iterm.writeEscapeToSession(sessionId, `\x1b]9;${msg}\x07`);
   }
 
   async renameWorkspace(_sessionId: string, _name: string): Promise<void> {

--- a/src/iterm.ts
+++ b/src/iterm.ts
@@ -140,6 +140,41 @@ export async function writeToSession(
 }
 
 /**
+ * Get the TTY device path for a specific iTerm2 session.
+ */
+export async function sessionTty(sessionId: string): Promise<string | null> {
+  try {
+    return await osascript(`
+      tell application "iTerm2"
+        repeat with w in windows
+          repeat with t in tabs of w
+            repeat with s in sessions of t
+              if id of s is "${sessionId}" then
+                return tty of s
+              end if
+            end repeat
+          end repeat
+        end repeat
+      end tell
+    `);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write an escape sequence directly to a session's TTY.
+ * Unlike writeToSession (which types text as input), this writes raw bytes
+ * to the terminal device — works even when the session is busy.
+ */
+export async function writeEscapeToSession(sessionId: string, escape: string): Promise<void> {
+  const tty = await sessionTty(sessionId);
+  if (!tty) return;
+  const { writeFileSync } = await import("fs");
+  writeFileSync(tty, escape);
+}
+
+/**
  * Close a specific iTerm2 session.
  * Throws if the session is not found or the close fails.
  */


### PR DESCRIPTION
## Summary
- **flashSession**: writes `OSC 1337 RequestAttention=fireworks` to session TTY — bounces the dock icon
- **notifySession**: writes `OSC 9` to session TTY — macOS notification banner. No longer clobbers the badge.
- New helpers: `sessionTty()` gets TTY path via AppleScript, `writeEscapeToSession()` writes raw bytes directly

## Why direct TTY write?
`writeToSession` types text as input (shell has to be at a prompt). `writeEscapeToSession` writes raw bytes to the TTY device — works even when CC is running.

## Test plan
- [x] `sessionTty()` returns valid `/dev/ttysNNN` for iTerm2 sessions
- [x] Direct TTY write of OSC 9 tested
- [x] Compilation verified
- [ ] Visual: confirm dock bounce and notification banner appear

Fixes #6, #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)