### PR TITLE
feat: crypto + session tests, collapse setTabName

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/claude-session.test.ts
+++ b/src/claude-session.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { getClaudeCodeSessionId } from "./claude-session";
+import { mkdtempSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+describe("claude-session", () => {
+  test("returns null when no session file exists for ppid", () => {
+    // In test context, ppid is bun's parent (not claude), so no session file
+    const id = getClaudeCodeSessionId();
+    expect(id).toBeNull();
+  });
+
+  test("reads session ID from mock session file", () => {
+    // Create a mock sessions dir with a file for our ppid
+    const tmpDir = mkdtempSync(join(tmpdir(), "claude-session-test-"));
+    const sessionsDir = join(tmpDir, ".claude", "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+
+    const mockSessionId = "test-uuid-1234-5678";
+    writeFileSync(
+      join(sessionsDir, `${process.ppid}.json`),
+      JSON.stringify({ pid: process.ppid, sessionId: mockSessionId, cwd: "/tmp" }),
+    );
+
+    // Override HOME to point to our mock
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    try {
+      const id = getClaudeCodeSessionId();
+      expect(id).toBe(mockSessionId);
+    } finally {
+      process.env.HOME = origHome;
+    }
+  });
+
+  test("returns null for malformed session file", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "claude-session-test-"));
+    const sessionsDir = join(tmpDir, ".claude", "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+
+    writeFileSync(join(sessionsDir, `${process.ppid}.json`), "not json");
+
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    try {
+      const id = getClaudeCodeSessionId();
+      expect(id).toBeNull();
+    } finally {
+      process.env.HOME = origHome;
+    }
+  });
+
+  test("returns null for session file without sessionId field", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "claude-session-test-"));
+    const sessionsDir = join(tmpDir, ".claude", "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+
+    writeFileSync(join(sessionsDir, `${process.ppid}.json`), JSON.stringify({ pid: 1234 }));
+
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    try {
+      const id = getClaudeCodeSessionId();
+      expect(id).toBeNull();
+    } finally {
+      process.env.HOME = origHome;
+    }
+  });
+});

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -160,16 +160,6 @@ export class CmuxBackend implements TerminalBackend {
     }
   }
 
-  async setTabName(_sessionId: string, name: string): Promise<void> {
-    try {
-      if (process.env.CMUX_WORKSPACE_ID) {
-        await cmux("rename-workspace", "--workspace", process.env.CMUX_WORKSPACE_ID, name);
-      }
-    } catch {
-      // No-op if not supported
-    }
-  }
-
   async setBadge(sessionId: string, text: string): Promise<void> {
     try {
       await cmux("notify", "--title", text, "--surface", sessionId);

--- a/src/crypto.test.ts
+++ b/src/crypto.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "bun:test";
+import { generateKeyPair, exportPrivateKey, importPrivateKey, importKeyPair } from "./crypto";
+
+describe("crypto", () => {
+  test("generateKeyPair returns publicKey string and privateKey CryptoKey", async () => {
+    const kp = await generateKeyPair();
+    expect(typeof kp.publicKey).toBe("string");
+    expect(kp.publicKey.length).toBeGreaterThan(0);
+    expect(kp.privateKey).toBeInstanceOf(CryptoKey);
+  });
+
+  test("exportPrivateKey returns base64 string", async () => {
+    const kp = await generateKeyPair();
+    const exported = await exportPrivateKey(kp.privateKey);
+    expect(typeof exported).toBe("string");
+    expect(exported.length).toBeGreaterThan(0);
+    // Should be valid base64
+    expect(() => atob(exported)).not.toThrow();
+  });
+
+  test("importPrivateKey round-trips with exportPrivateKey", async () => {
+    const kp = await generateKeyPair();
+    const exported = await exportPrivateKey(kp.privateKey);
+    const imported = await importPrivateKey(exported);
+    expect(imported).toBeInstanceOf(CryptoKey);
+    // Re-export should produce the same base64
+    const reExported = await exportPrivateKey(imported);
+    expect(reExported).toBe(exported);
+  });
+
+  test("importKeyPair returns matching publicKey", async () => {
+    const kp = await generateKeyPair();
+    const exported = await exportPrivateKey(kp.privateKey);
+    const reimported = await importKeyPair(exported);
+    expect(reimported.publicKey).toBe(kp.publicKey);
+  });
+
+  test("two generateKeyPair calls produce different keys", async () => {
+    const kp1 = await generateKeyPair();
+    const kp2 = await generateKeyPair();
+    expect(kp1.publicKey).not.toBe(kp2.publicKey);
+  });
+});

--- a/src/iterm-backend.ts
+++ b/src/iterm-backend.ts
@@ -47,10 +47,6 @@ export class ItermBackend implements TerminalBackend {
     return iterm.setSessionName(sessionId, name);
   }
 
-  setTabName(sessionId: string, name: string): Promise<void> {
-    return iterm.setTabName(sessionId, name);
-  }
-
   setBadge(sessionId: string, text: string): Promise<void> {
     return iterm.setBadge(sessionId, text);
   }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -69,9 +69,6 @@ export interface TerminalBackend {
   /** Set the title/name of a session/surface. */
   setSessionName(sessionId: string, name: string): Promise<void>;
 
-  /** Set the tab/workspace name (may be a no-op on some backends). */
-  setTabName(sessionId: string, name: string): Promise<void>;
-
   /** Set a badge/status overlay on a session/surface. */
   setBadge(sessionId: string, text: string): Promise<void>;
 


### PR DESCRIPTION
## Summary
- **9 new tests**: crypto round-trip (5) + claude-session detection (4). Total: 33 tests.
- **Remove setTabName** from TerminalBackend — was no-op on iTerm2, buggy on cmux (#2). `renameWorkspace` handles both backends correctly.

## Test results
```
33 pass, 0 fail, 59 expect() calls [128ms]
```

Fixes #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)