### PR TITLE
feat: reconcile heals pane/tab drift (v1.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -846,7 +846,7 @@ export class Orchestrator {
    * Run on boot and periodically.
    */
   async reconcile(): Promise<string> {
-    const result = await reconcile(this.store);
+    const result = await reconcile(this.store, this.terminal);
     const agents = this.store.listAgents();
     return formatReport(result, agents);
   }

--- a/src/reconciler.test.ts
+++ b/src/reconciler.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { CrewStore } from "./store";
+import { reconcile } from "./reconciler";
+import type { TerminalBackend } from "./terminal";
+import { mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+let store: CrewStore;
+
+beforeEach(() => {
+  const tmp = mkdtempSync(join(tmpdir(), "reconciler-test-"));
+  store = new CrewStore(join(tmp, "test.db"));
+});
+
+function makeTerminal(aliveSessionIds: string[]): TerminalBackend {
+  const alive = new Set(aliveSessionIds);
+  return {
+    name: "test",
+    currentSessionId: mock(async () => ""),
+    sessionIdForTty: mock(async () => null),
+    splitPane: mock(async () => ""),
+    splitSession: mock(async () => ""),
+    writeToSession: mock(async () => {}),
+    closeSession: mock(async () => {}),
+    isSessionAlive: mock(async (id: string) => alive.has(id)),
+    createTab: mock(async () => ""),
+    setSessionName: mock(async () => {}),
+    setBadge: mock(async () => {}),
+    flashSession: mock(async () => {}),
+    notifySession: mock(async () => {}),
+    renameWorkspace: mock(async () => {}),
+    writePaneProfile: mock(() => ""),
+    writeEmptyPaneProfile: mock(() => ""),
+    splitPaneWithProfile: mock(async () => ""),
+    splitSessionWithProfile: mock(async () => ""),
+    splitWebBrowser: mock(async () => ""),
+    splitSessionWebBrowser: mock(async () => ""),
+  } as unknown as TerminalBackend;
+}
+
+describe("reconcile theme healing", () => {
+  test("assigns theme to untheme tab", async () => {
+    store.createTab("brioche");
+    const result = await reconcile(store);
+    expect(result.tabsThemed.length).toBe(1);
+    expect(result.tabsThemed[0].tab).toBe("brioche");
+    expect(result.tabsThemed[0].theme).toBeDefined();
+    expect(store.getTab("brioche")!.theme).toBe(result.tabsThemed[0].theme);
+  });
+
+  test("skips tabs that already have a theme", async () => {
+    store.createTab("eng", "trees");
+    const result = await reconcile(store);
+    expect(result.tabsThemed.length).toBe(0);
+    expect(store.getTab("eng")!.theme).toBe("trees");
+  });
+
+  test("picks unused theme when others are taken", async () => {
+    store.createTab("a", "trees");
+    store.createTab("b"); // no theme
+    const result = await reconcile(store);
+    expect(result.tabsThemed.length).toBe(1);
+    expect(result.tabsThemed[0].theme).not.toBe("trees");
+  });
+
+  test("pane inherits theme from tab", async () => {
+    store.createTab("eng", "trees");
+    store.createPane("oak", "eng"); // no theme
+    const result = await reconcile(store);
+    expect(result.panesThemed.length).toBe(1);
+    expect(result.panesThemed[0]).toEqual({ pane: "oak", theme: "trees" });
+    expect(store.getPane("oak")!.theme).toBe("trees");
+  });
+});
+
+describe("reconcile terminal session checks", () => {
+  test("clears dead pane iterm_id", async () => {
+    store.createTab("eng", "trees");
+    store.createPane("oak", "eng");
+    store.setPaneItermId("oak", "session-dead");
+    const terminal = makeTerminal([]);
+    const result = await reconcile(store, terminal);
+    expect(result.panesCleared).toEqual(["oak"]);
+    expect(store.getPane("oak")!.iterm_id).toBeNull();
+  });
+
+  test("keeps alive pane iterm_id", async () => {
+    store.createTab("eng", "trees");
+    store.createPane("oak", "eng");
+    store.setPaneItermId("oak", "session-live");
+    const terminal = makeTerminal(["session-live"]);
+    const result = await reconcile(store, terminal);
+    expect(result.panesCleared).toEqual([]);
+    expect(store.getPane("oak")!.iterm_id).toBe("session-live");
+  });
+
+  test("clears dead tab session", async () => {
+    store.createTab("eng", "trees", "session-dead");
+    const terminal = makeTerminal([]);
+    const result = await reconcile(store, terminal);
+    expect(result.tabsCleared).toEqual(["eng"]);
+    expect(store.getTab("eng")!.iterm_session_id).toBeNull();
+  });
+
+  test("skips terminal checks when backend omitted", async () => {
+    store.createTab("eng", "trees");
+    store.createPane("oak", "eng");
+    store.setPaneItermId("oak", "session-anything");
+    const result = await reconcile(store); // no terminal
+    expect(result.panesCleared).toEqual([]);
+    expect(result.tabsCleared).toEqual([]);
+    expect(store.getPane("oak")!.iterm_id).toBe("session-anything");
+  });
+});

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -1,26 +1,38 @@
 /**
- * Agent reconciler — sync SQLite state with actual screen sessions.
+ * Reconciler — sync SQLite state with actual terminal + screen reality.
  *
- * Same pattern as the Wire session reconciler:
- * 1. Read all agents from DB
- * 2. Check screen -ls for live sessions
- * 3. Mark dead agents, clear their panes
- * 4. Flag orphan screen sessions
+ * Covers three drift surfaces:
+ * 1. Agents ↔ screen sessions (dead agents cleaned up, orphan screens flagged)
+ * 2. Panes ↔ terminal sessions (pane.iterm_id cleared if session gone)
+ * 3. Tabs ↔ terminal sessions + theme sanity (missing themes auto-assigned,
+ *    dead iterm_session_id cleared)
  */
 
 import { CrewStore, type Agent } from "./store.js";
 import { listSessions, type ScreenSession } from "./screen.js";
+import { listThemes } from "./themes.js";
+import type { TerminalBackend } from "./terminal.js";
 
 export type ReconcileResult = {
   alive: string[];
   dead: string[];
   orphans: ScreenSession[];
+  panesCleared: string[];
+  tabsCleared: string[];
+  tabsThemed: Array<{ tab: string; theme: string }>;
+  panesThemed: Array<{ pane: string; theme: string }>;
 };
 
 /**
- * Reconcile DB state with running screen sessions.
+ * Reconcile DB state with running screen sessions and terminal state.
+ *
+ * Terminal backend is optional — if omitted, pane/tab session checks are
+ * skipped. Theme healing runs unconditionally.
  */
-export async function reconcile(store: CrewStore): Promise<ReconcileResult> {
+export async function reconcile(
+  store: CrewStore,
+  terminal?: TerminalBackend,
+): Promise<ReconcileResult> {
   const agents = store.listAgents();
   const sessions = await listSessions();
   const sessionByName = new Map(sessions.map((s) => [s.name, s]));
@@ -34,24 +46,68 @@ export async function reconcile(store: CrewStore): Promise<ReconcileResult> {
     const session = sessionByName.get(agent.screen_name);
 
     if (session) {
-      // Alive — update PID and last_seen
       store.updateAgentPid(agent.id, session.pid);
       store.touchAgent(agent.id);
       alive.push(agent.id);
     } else {
-      // Dead — clear pane, remove from DB
       store.deleteAgent(agent.id);
       dead.push(agent.id);
     }
   }
 
-  // Find orphan screen sessions (not tracked in DB)
-  // Only flag sessions with our naming prefix
   const orphans = sessions.filter(
     (s) => s.name.startsWith("wire-") && !knownScreenNames.has(s.name),
   );
 
-  return { alive, dead, orphans };
+  // --- Pane session check ---
+  const panesCleared: string[] = [];
+  if (terminal) {
+    for (const pane of store.listPanes()) {
+      if (!pane.iterm_id) continue;
+      const alive = await terminal.isSessionAlive(pane.iterm_id).catch(() => false);
+      if (!alive) {
+        store.clearPaneItermId(pane.name);
+        panesCleared.push(pane.name);
+      }
+    }
+  }
+
+  // --- Tab session check + theme heal ---
+  const tabsCleared: string[] = [];
+  const tabsThemed: Array<{ tab: string; theme: string }> = [];
+  const availableThemes = listThemes();
+
+  for (const tab of store.listTabs()) {
+    if (terminal && tab.iterm_session_id) {
+      const alive = await terminal.isSessionAlive(tab.iterm_session_id).catch(() => false);
+      if (!alive) {
+        store.clearTabSession(tab.name);
+        tabsCleared.push(tab.name);
+      }
+    }
+
+    if (!tab.theme && availableThemes.length > 0) {
+      const usedThemes = new Set(
+        store.listTabs().map((t) => t.theme).filter(Boolean) as string[],
+      );
+      const picked = availableThemes.find((t) => !usedThemes.has(t)) ?? availableThemes[0];
+      store.setTabTheme(tab.name, picked);
+      tabsThemed.push({ tab: tab.name, theme: picked });
+    }
+  }
+
+  // --- Pane theme heal (inherit from tab) ---
+  const panesThemed: Array<{ pane: string; theme: string }> = [];
+  for (const pane of store.listPanes()) {
+    if (pane.theme) continue;
+    const tab = store.getTab(pane.tab);
+    if (tab?.theme) {
+      store.setPaneTheme(pane.name, tab.theme);
+      panesThemed.push({ pane: pane.name, theme: tab.theme });
+    }
+  }
+
+  return { alive, dead, orphans, panesCleared, tabsCleared, tabsThemed, panesThemed };
 }
 
 /**
@@ -69,6 +125,18 @@ export function formatReport(result: ReconcileResult, agents: Agent[]): string {
   }
   if (result.orphans.length > 0) {
     lines.push(`${result.orphans.length} orphan screen session(s): ${result.orphans.map((o) => o.name).join(", ")}`);
+  }
+  if (result.panesCleared.length > 0) {
+    lines.push(`${result.panesCleared.length} pane(s) with dead terminal session: ${result.panesCleared.join(", ")}`);
+  }
+  if (result.tabsCleared.length > 0) {
+    lines.push(`${result.tabsCleared.length} tab(s) with dead terminal session: ${result.tabsCleared.join(", ")}`);
+  }
+  if (result.tabsThemed.length > 0) {
+    lines.push(`${result.tabsThemed.length} tab(s) auto-themed: ${result.tabsThemed.map((t) => `${t.tab}→${t.theme}`).join(", ")}`);
+  }
+  if (result.panesThemed.length > 0) {
+    lines.push(`${result.panesThemed.length} pane(s) theme inherited from tab: ${result.panesThemed.map((p) => `${p.pane}→${p.theme}`).join(", ")}`);
   }
 
   for (const agent of agents) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -217,6 +217,18 @@ export class CrewStore {
     this.db.prepare("UPDATE panes SET iterm_id = ? WHERE name = ?").run(itermId, name);
   }
 
+  clearPaneItermId(name: string): void {
+    this.db.prepare("UPDATE panes SET iterm_id = NULL WHERE name = ?").run(name);
+  }
+
+  setPaneTheme(name: string, theme: string): void {
+    this.db.prepare("UPDATE panes SET theme = ? WHERE name = ?").run(theme, name);
+  }
+
+  clearTabSession(name: string): void {
+    this.db.prepare("UPDATE tabs SET iterm_session_id = NULL WHERE name = ?").run(name);
+  }
+
   deletePane(name: string): void {
     // Detach any agent in this pane
     this.db.prepare("UPDATE agents SET pane = NULL WHERE pane = ?").run(name);


### PR DESCRIPTION
## Summary
Extends `reconcile()` beyond agents to heal pane + tab drift:
- Clears `pane.iterm_id` for dead terminal sessions
- Clears `tab.iterm_session_id` for dead terminal sessions  
- Auto-assigns theme to un-themed tabs (first unused, matches `createTab`)
- Inherits tab theme onto un-themed panes

## Why
Previously only agents ↔ screen sessions were reality-checked. Tab/pane state drifted forever. Brioche's `brioche` tab has no theme because it predates the auto-theme-pick feature and nothing heals legacy tabs.

## Test plan
- [x] 8 new reconciler tests (4 heal paths + alive cases + terminal-omitted fallback)
- [x] All 41 existing tests still pass