### PR TITLE
fix: cc_session_id from sessions file (v1.2.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -12,6 +12,7 @@ import type { TerminalBackend } from "./terminal.js";
 import { getLaunchCommand } from "./runtimes.js";
 import { reconcile, formatReport } from "./reconciler.js";
 import { pickName, backgroundImagePath, loadTheme, updateTheme, listThemes } from "./themes.js";
+import { getClaudeCodeSessionId } from "./claude-session.js";
 
 const DEFAULT_DB = join(process.env.HOME ?? "/tmp", ".wire", "crews.db");
 const SCREEN_PREFIX = "wire-";
@@ -127,7 +128,7 @@ export class Orchestrator {
     ccSessionId?: string;
   }): Promise<Agent> {
     const runtime = opts.runtime ?? "claude-code";
-    const ccSessionId = opts.ccSessionId ?? process.env.CLAUDE_CODE_SESSION_ID;
+    const ccSessionId = opts.ccSessionId ?? getClaudeCodeSessionId() ?? undefined;
 
     // Detect screen session from STY (format: "pid.name")
     const sty = process.env.STY;


### PR DESCRIPTION
registerAgent was reading process.env.CLAUDE_CODE_SESSION_ID (always empty). Switched to getClaudeCodeSessionId() which reads ~/.claude/sessions/<ppid>.json — same mechanism mcp-server already uses.