### PR TITLE
fix: walk process tree to find Claude session file (v1.2.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/claude-session.test.ts
+++ b/src/claude-session.test.ts
@@ -5,10 +5,38 @@ import { join } from "path";
 import { tmpdir } from "os";
 
 describe("claude-session", () => {
-  test("returns null when no session file exists for ppid", () => {
-    // In test context, ppid is bun's parent (not claude), so no session file
-    const id = getClaudeCodeSessionId();
-    expect(id).toBeNull();
+  test("returns null when no session file exists in any ancestor", () => {
+    // Point HOME at an empty dir so the walk-up finds nothing.
+    const tmpDir = mkdtempSync(join(tmpdir(), "claude-session-test-"));
+    mkdirSync(join(tmpDir, ".claude", "sessions"), { recursive: true });
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    try {
+      expect(getClaudeCodeSessionId()).toBeNull();
+    } finally {
+      process.env.HOME = origHome;
+    }
+  });
+
+  test("walks up the process tree to find session file", () => {
+    // Get the actual ancestor chain: ppid → ppid.ppid → ...
+    // The test process's grandparent (or higher) might be the test runner,
+    // which is itself launched from somewhere. Write the session file at the
+    // immediate ppid — the simplest case the walk handles.
+    const tmpDir = mkdtempSync(join(tmpdir(), "claude-session-test-"));
+    const sessionsDir = join(tmpDir, ".claude", "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+    writeFileSync(
+      join(sessionsDir, `${process.ppid}.json`),
+      JSON.stringify({ pid: process.ppid, sessionId: "ancestor-uuid", cwd: "/tmp" }),
+    );
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+    try {
+      expect(getClaudeCodeSessionId()).toBe("ancestor-uuid");
+    } finally {
+      process.env.HOME = origHome;
+    }
   });
 
   test("reads session ID from mock session file", () => {

--- a/src/claude-session.ts
+++ b/src/claude-session.ts
@@ -1,23 +1,48 @@
 /**
  * Read the Claude Code session ID for the current process.
  *
- * CC persists session data at ~/.claude/sessions/<PID>.json.
- * MCP servers are direct children of the CC process, so process.ppid
- * gives us the CC PID. The session ID is stable across process restarts
- * — the same CC session can resume into a new PID.
+ * CC persists session data at ~/.claude/sessions/<PID>.json (keyed by
+ * the CC process's own PID). MCP servers are NOT necessarily direct
+ * children of the CC process — bun's `bun run` wrapper inserts a layer,
+ * so process.ppid is the wrapper, not CC. We walk up the process tree
+ * looking for an ancestor whose sessions/<pid>.json exists.
  */
 
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
+import { execSync } from "child_process";
 
-export function getClaudeCodeSessionId(): string | null {
-  const sessionsDir = join(process.env.HOME ?? "/tmp", ".claude", "sessions");
-  const sessionFile = join(sessionsDir, `${process.ppid}.json`);
-  if (!existsSync(sessionFile)) return null;
+const MAX_DEPTH = 10;
+
+function getParentPid(pid: number): number | null {
   try {
-    const data = JSON.parse(readFileSync(sessionFile, "utf-8"));
-    return data.sessionId ?? null;
+    const out = execSync(`ps -o ppid= -p ${pid}`, { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+    const parent = parseInt(out, 10);
+    if (!parent || parent === 1 || parent === pid) return null;
+    return parent;
   } catch {
     return null;
   }
+}
+
+export function getClaudeCodeSessionId(): string | null {
+  const sessionsDir = join(process.env.HOME ?? "/tmp", ".claude", "sessions");
+  let pid: number | null = process.ppid;
+
+  for (let depth = 0; depth < MAX_DEPTH && pid; depth++) {
+    const sessionFile = join(sessionsDir, `${pid}.json`);
+    if (existsSync(sessionFile)) {
+      try {
+        const data = JSON.parse(readFileSync(sessionFile, "utf-8"));
+        if (data.sessionId) return data.sessionId;
+      } catch {
+        // Malformed file — keep walking up in case a higher ancestor has a valid one.
+      }
+    }
+    pid = getParentPid(pid);
+  }
+
+  return null;
 }


### PR DESCRIPTION
v1.2.1's process.ppid lookup hit the bun-run wrapper, not CC. Walk ancestors until a sessions/<pid>.json is found.