### PR TITLE
feat: reconcile applies themes to live sessions (v1.3.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -216,6 +216,11 @@ export class CmuxBackend implements TerminalBackend {
     return "cmux-default";
   }
 
+  async setProfile(_sessionId: string, _profileName: string): Promise<void> {
+    // cmux has no dynamic-profile concept — background images live in theme.json
+    // sidebar metadata, not per-session profiles. No-op.
+  }
+
   async splitPaneWithProfile(
     direction: "horizontal" | "vertical",
     _profileName: string,

--- a/src/iterm-backend.ts
+++ b/src/iterm-backend.ts
@@ -68,6 +68,11 @@ export class ItermBackend implements TerminalBackend {
     return "Crew Empty Pane";
   }
 
+  async setProfile(sessionId: string, profileName: string): Promise<void> {
+    // OSC 1337 SetProfile= switches the session to a named (dynamic) profile.
+    await iterm.writeEscapeToSession(sessionId, `\x1b]1337;SetProfile=${profileName}\x07`);
+  }
+
   splitPaneWithProfile(
     direction: "horizontal" | "vertical",
     profileName: string,

--- a/src/reconciler.test.ts
+++ b/src/reconciler.test.ts
@@ -13,10 +13,22 @@ beforeEach(() => {
   store = new CrewStore(join(tmp, "test.db"));
 });
 
-function makeTerminal(aliveSessionIds: string[]): TerminalBackend {
+type TerminalCalls = {
+  setSessionName: Array<{ sessionId: string; name: string }>;
+  writePaneProfile: Array<{ paneName: string; backgroundImage?: string }>;
+  setProfile: Array<{ sessionId: string; profileName: string }>;
+};
+
+function makeTerminal(aliveSessionIds: string[]): TerminalBackend & { calls: TerminalCalls } {
   const alive = new Set(aliveSessionIds);
-  return {
+  const calls: TerminalCalls = {
+    setSessionName: [],
+    writePaneProfile: [],
+    setProfile: [],
+  };
+  const t: TerminalBackend & { calls: TerminalCalls } = {
     name: "test",
+    calls,
     currentSessionId: mock(async () => ""),
     sessionIdForTty: mock(async () => null),
     splitPane: mock(async () => ""),
@@ -25,18 +37,27 @@ function makeTerminal(aliveSessionIds: string[]): TerminalBackend {
     closeSession: mock(async () => {}),
     isSessionAlive: mock(async (id: string) => alive.has(id)),
     createTab: mock(async () => ""),
-    setSessionName: mock(async () => {}),
+    setSessionName: mock(async (sessionId: string, name: string) => {
+      calls.setSessionName.push({ sessionId, name });
+    }),
     setBadge: mock(async () => {}),
     flashSession: mock(async () => {}),
     notifySession: mock(async () => {}),
     renameWorkspace: mock(async () => {}),
-    writePaneProfile: mock(() => ""),
-    writeEmptyPaneProfile: mock(() => ""),
+    writePaneProfile: mock((profile: { paneName: string; backgroundImage?: string }) => {
+      calls.writePaneProfile.push({ paneName: profile.paneName, backgroundImage: profile.backgroundImage });
+      return `Crew ${profile.paneName}`;
+    }),
+    writeEmptyPaneProfile: mock(() => "Crew Empty Pane"),
+    setProfile: mock(async (sessionId: string, profileName: string) => {
+      calls.setProfile.push({ sessionId, profileName });
+    }),
     splitPaneWithProfile: mock(async () => ""),
     splitSessionWithProfile: mock(async () => ""),
     splitWebBrowser: mock(async () => ""),
     splitSessionWebBrowser: mock(async () => ""),
-  } as unknown as TerminalBackend;
+  } as unknown as TerminalBackend & { calls: TerminalCalls };
+  return t;
 }
 
 describe("reconcile theme healing", () => {
@@ -101,6 +122,57 @@ describe("reconcile terminal session checks", () => {
     const result = await reconcile(store, terminal);
     expect(result.tabsCleared).toEqual(["eng"]);
     expect(store.getTab("eng")!.iterm_session_id).toBeNull();
+  });
+
+  test("renames non-pool pane to a themed name and applies profile", async () => {
+    // brioche tab is themed cities; the test-east pane name is NOT in the cities pool.
+    store.createTab("brioche", "cities");
+    store.createPane("test-east", "brioche", "", "cities");
+    store.setPaneItermId("test-east", "session-brioche");
+    const terminal = makeTerminal(["session-brioche"]);
+    const result = await reconcile(store, terminal);
+
+    expect(result.panesRenamed.length).toBe(1);
+    expect(result.panesRenamed[0].from).toBe("test-east");
+    expect(result.panesRenamed[0].theme).toBe("cities");
+    const newName = result.panesRenamed[0].to;
+
+    // Pane was renamed in DB
+    expect(store.getPane("test-east")).toBeNull();
+    expect(store.getPane(newName)).not.toBeNull();
+
+    // setSessionName was called on the live session with title-cased new name
+    expect(terminal.calls.setSessionName.some((c) => c.sessionId === "session-brioche")).toBe(true);
+
+    // Profile was written and applied
+    expect(result.profilesApplied.length).toBe(1);
+    expect(terminal.calls.setProfile.some((c) => c.sessionId === "session-brioche")).toBe(true);
+  });
+
+  test("skips rename when pane name is already in the theme's pool", async () => {
+    // 'paris' IS in the cities pool, so no rename should happen.
+    store.createTab("fabrica", "cities");
+    store.createPane("paris", "fabrica", "", "cities");
+    store.setPaneItermId("paris", "session-paris");
+    const terminal = makeTerminal(["session-paris"]);
+    const result = await reconcile(store, terminal);
+
+    expect(result.panesRenamed).toEqual([]);
+    // But profile should still be applied (the heal applies even without rename)
+    expect(result.profilesApplied.length).toBe(1);
+    expect(result.profilesApplied[0].pane).toBe("paris");
+  });
+
+  test("skips heal when pane has no iterm_id", async () => {
+    store.createTab("brioche", "cities");
+    store.createPane("test-east", "brioche", "", "cities");
+    // no setPaneItermId — pane is not bound to a session
+    const terminal = makeTerminal([]);
+    const result = await reconcile(store, terminal);
+
+    expect(result.panesRenamed).toEqual([]);
+    expect(result.profilesApplied).toEqual([]);
+    expect(store.getPane("test-east")).not.toBeNull();
   });
 
   test("skips terminal checks when backend omitted", async () => {

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -1,17 +1,24 @@
 /**
  * Reconciler — sync SQLite state with actual terminal + screen reality.
  *
- * Covers three drift surfaces:
+ * Covers four drift surfaces:
  * 1. Agents ↔ screen sessions (dead agents cleaned up, orphan screens flagged)
  * 2. Panes ↔ terminal sessions (pane.iterm_id cleared if session gone)
  * 3. Tabs ↔ terminal sessions + theme sanity (missing themes auto-assigned,
  *    dead iterm_session_id cleared)
+ * 4. Live theme application — for panes with iterm_id + a theme, ensure the
+ *    pane name comes from the theme's pool (rename if not), then write the
+ *    themed profile and apply it to the running session via setProfile.
  */
 
 import { CrewStore, type Agent } from "./store.js";
 import { listSessions, type ScreenSession } from "./screen.js";
-import { listThemes } from "./themes.js";
+import { listThemes, loadTheme, pickName, backgroundImagePath } from "./themes.js";
 import type { TerminalBackend } from "./terminal.js";
+
+function titleCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
 
 export type ReconcileResult = {
   alive: string[];
@@ -21,14 +28,10 @@ export type ReconcileResult = {
   tabsCleared: string[];
   tabsThemed: Array<{ tab: string; theme: string }>;
   panesThemed: Array<{ pane: string; theme: string }>;
+  panesRenamed: Array<{ from: string; to: string; theme: string }>;
+  profilesApplied: Array<{ pane: string; profile: string }>;
 };
 
-/**
- * Reconcile DB state with running screen sessions and terminal state.
- *
- * Terminal backend is optional — if omitted, pane/tab session checks are
- * skipped. Theme healing runs unconditionally.
- */
 export async function reconcile(
   store: CrewStore,
   terminal?: TerminalBackend,
@@ -44,7 +47,6 @@ export async function reconcile(
   for (const agent of agents) {
     knownScreenNames.add(agent.screen_name);
     const session = sessionByName.get(agent.screen_name);
-
     if (session) {
       store.updateAgentPid(agent.id, session.pid);
       store.touchAgent(agent.id);
@@ -64,8 +66,8 @@ export async function reconcile(
   if (terminal) {
     for (const pane of store.listPanes()) {
       if (!pane.iterm_id) continue;
-      const alive = await terminal.isSessionAlive(pane.iterm_id).catch(() => false);
-      if (!alive) {
+      const isAlive = await terminal.isSessionAlive(pane.iterm_id).catch(() => false);
+      if (!isAlive) {
         store.clearPaneItermId(pane.name);
         panesCleared.push(pane.name);
       }
@@ -79,8 +81,8 @@ export async function reconcile(
 
   for (const tab of store.listTabs()) {
     if (terminal && tab.iterm_session_id) {
-      const alive = await terminal.isSessionAlive(tab.iterm_session_id).catch(() => false);
-      if (!alive) {
+      const isAlive = await terminal.isSessionAlive(tab.iterm_session_id).catch(() => false);
+      if (!isAlive) {
         store.clearTabSession(tab.name);
         tabsCleared.push(tab.name);
       }
@@ -107,12 +109,66 @@ export async function reconcile(
     }
   }
 
-  return { alive, dead, orphans, panesCleared, tabsCleared, tabsThemed, panesThemed };
+  // --- Live theme application: rename to pool name if needed, write+apply profile ---
+  const panesRenamed: Array<{ from: string; to: string; theme: string }> = [];
+  const profilesApplied: Array<{ pane: string; profile: string }> = [];
+  if (terminal) {
+    // Re-fetch panes after rename to get current name
+    let panesSnapshot = store.listPanes();
+    for (let i = 0; i < panesSnapshot.length; i++) {
+      const original = panesSnapshot[i];
+      if (!original.iterm_id || !original.theme) continue;
+
+      let workingName = original.name;
+      const themeConfig = loadTheme(original.theme);
+      const pool = themeConfig?.pool ?? [];
+
+      // If pane's current name isn't in the theme's pool, swap to an unused pool name.
+      if (pool.length > 0 && !pool.includes(workingName)) {
+        const usedNames = store.listPanes().map((p) => p.name);
+        const newName = pickName(original.theme, usedNames);
+        if (newName) {
+          try {
+            store.renamePane(workingName, newName);
+            await terminal.setSessionName(original.iterm_id, titleCase(newName));
+            panesRenamed.push({ from: workingName, to: newName, theme: original.theme });
+            workingName = newName;
+            // Refresh local snapshot index
+            panesSnapshot = store.listPanes();
+          } catch (e) {
+            console.error(`[crew] reconcile: failed to rename pane '${workingName}' → '${newName}':`, e);
+            continue;
+          }
+        }
+      }
+
+      // Build the themed profile and apply it to the live session.
+      const bgPath = backgroundImagePath(original.theme, workingName, themeConfig);
+      const badgeColor = themeConfig?.badgeColors?.[workingName] ?? themeConfig?.defaultBadgeColor;
+      try {
+        const profileName = terminal.writePaneProfile({
+          paneName: workingName,
+          backgroundImage: bgPath ?? undefined,
+          blend: themeConfig?.background.blend,
+          mode: themeConfig?.background.mode,
+          badgeColor,
+        });
+        await terminal.setProfile(original.iterm_id, profileName);
+        profilesApplied.push({ pane: workingName, profile: profileName });
+      } catch (e) {
+        console.error(`[crew] reconcile: failed to apply profile for pane '${workingName}':`, e);
+      }
+    }
+  }
+
+  return {
+    alive, dead, orphans,
+    panesCleared, tabsCleared,
+    tabsThemed, panesThemed,
+    panesRenamed, profilesApplied,
+  };
 }
 
-/**
- * Format a reconcile result as a human-readable boot report.
- */
 export function formatReport(result: ReconcileResult, agents: Agent[]): string {
   const lines: string[] = [];
   const attached = agents.filter((a) => a.pane);
@@ -137,6 +193,12 @@ export function formatReport(result: ReconcileResult, agents: Agent[]): string {
   }
   if (result.panesThemed.length > 0) {
     lines.push(`${result.panesThemed.length} pane(s) theme inherited from tab: ${result.panesThemed.map((p) => `${p.pane}→${p.theme}`).join(", ")}`);
+  }
+  if (result.panesRenamed.length > 0) {
+    lines.push(`${result.panesRenamed.length} pane(s) renamed to themed pool: ${result.panesRenamed.map((p) => `${p.from}→${p.to} (${p.theme})`).join(", ")}`);
+  }
+  if (result.profilesApplied.length > 0) {
+    lines.push(`${result.profilesApplied.length} pane profile(s) applied: ${result.profilesApplied.map((p) => `${p.pane}=${p.profile}`).join(", ")}`);
   }
 
   for (const agent of agents) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -225,6 +225,19 @@ export class CrewStore {
     this.db.prepare("UPDATE panes SET theme = ? WHERE name = ?").run(theme, name);
   }
 
+  /**
+   * Rename a pane and update all FK references (agents.pane).
+   * Throws if `to` already exists.
+   */
+  renamePane(from: string, to: string): void {
+    if (from === to) return;
+    if (this.getPane(to)) throw new Error(`pane '${to}' already exists`);
+    this.db.transaction(() => {
+      this.db.prepare("UPDATE panes SET name = ? WHERE name = ?").run(to, from);
+      this.db.prepare("UPDATE agents SET pane = ? WHERE pane = ?").run(to, from);
+    })();
+  }
+
   clearTabSession(name: string): void {
     this.db.prepare("UPDATE tabs SET iterm_session_id = NULL WHERE name = ?").run(name);
   }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -85,6 +85,13 @@ export interface TerminalBackend {
   writeEmptyPaneProfile(): string;
 
   /**
+   * Apply a named profile to an existing session.
+   * iTerm2: writes OSC 1337 SetProfile= to the session's TTY.
+   * cmux: no-op (cmux has no equivalent dynamic-profile concept).
+   */
+  setProfile(sessionId: string, profileName: string): Promise<void>;
+
+  /**
    * Split the current pane using a named profile. Returns new session ID.
    * On cmux, profile is ignored — just does a normal split.
    */


### PR DESCRIPTION
Closes the gap where reconcile updated DB theme but didn't push profile to the live iTerm2 session. Adds setProfile, renamePane, and pool-name normalization.