### PR TITLE
fix: pane_create routing + pool name uniqueness (v1.3.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -487,14 +487,27 @@ export async function startServer(): Promise<void> {
           result = await orchestrator.registerPane(a.tab as string, a.name as string | undefined, sessionId);
           break;
         }
-        case "pane_create":
+        case "pane_create": {
+          // Only fall back to caller's session if creating in the caller's OWN tab.
+          // Cross-tab creates must NOT use the caller's pane as splitTarget — that's
+          // how new panes ended up in the caller's tab instead of the target.
+          const targetTab = a.tab as string;
+          let relTo = a.relative_to as string | undefined;
+          if (!relTo) {
+            const callerId = await callerSession();
+            if (callerId) {
+              const callerPane = orchestrator.store.listPanes().find((p) => p.iterm_id === callerId);
+              if (callerPane && callerPane.tab === targetTab) relTo = callerId;
+            }
+          }
           result = await orchestrator.createPane(
-            a.tab as string,
+            targetTab,
             a.name as string | undefined,
             a.position as string | undefined,
-            (a.relative_to as string) ?? await callerSession(),
+            relTo,
           );
           break;
+        }
         case "pane_send":
           await orchestrator.sendToPane(a.pane as string, a.text as string);
           result = { sent: true, pane: a.pane };

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -655,7 +655,10 @@ export class Orchestrator {
   nextPaneName(tab: string): string | null {
     const tabRow = this.store.getTab(tab);
     if (!tabRow?.theme) return null;
-    const usedNames = this.store.listPanes(tab).map((p) => p.name);
+    // Names are globally unique (panes.name PK), so check across ALL panes,
+    // not just this tab. Filtering per-tab caused pickName to return a name
+    // that already existed in another tab → INSERT hit UNIQUE constraint.
+    const usedNames = this.store.listPanes().map((p) => p.name);
     return pickName(tabRow.theme, usedNames);
   }
 

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -115,6 +115,29 @@ describe("panes", () => {
     expect(store.getPane("oak")).toBeNull();
     expect(store.getAgent("fondant")!.pane).toBeNull();
   });
+
+  test("renamePane updates pane row and agent FK", () => {
+    store.createPane("oak", "eng");
+    store.createAgent({ id: "fondant", display_name: "Fondant", runtime: "claude-code", screen_name: "wire-fondant", pane: "oak" });
+
+    store.renamePane("oak", "maple");
+
+    expect(store.getPane("oak")).toBeNull();
+    expect(store.getPane("maple")).not.toBeNull();
+    expect(store.getAgent("fondant")!.pane).toBe("maple");
+  });
+
+  test("renamePane is a no-op when from === to", () => {
+    store.createPane("oak", "eng");
+    store.renamePane("oak", "oak");
+    expect(store.getPane("oak")).not.toBeNull();
+  });
+
+  test("renamePane throws if target name exists", () => {
+    store.createPane("oak", "eng");
+    store.createPane("maple", "eng");
+    expect(() => store.renamePane("oak", "maple")).toThrow();
+  });
 });
 
 // --- Agents ---


### PR DESCRIPTION
Fixes #13 (pane_create lands in caller's tab) and #12 (pool exhaustion raw SQLiteError).