### PR TITLE
fix: reconcile refreshes session title + deletes dead-session panes (v1.3.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/reconciler.test.ts
+++ b/src/reconciler.test.ts
@@ -96,14 +96,24 @@ describe("reconcile theme healing", () => {
 });
 
 describe("reconcile terminal session checks", () => {
-  test("clears dead pane iterm_id", async () => {
+  test("deletes pane with dead session and no agent ref", async () => {
     store.createTab("eng", "trees");
     store.createPane("oak", "eng");
     store.setPaneItermId("oak", "session-dead");
     const terminal = makeTerminal([]);
     const result = await reconcile(store, terminal);
-    expect(result.panesCleared).toEqual(["oak"]);
-    expect(store.getPane("oak")!.iterm_id).toBeNull();
+    expect(result.panesDeleted).toEqual(["oak"]);
+    expect(result.panesCleared).toEqual([]);
+    expect(store.getPane("oak")).toBeNull();
+  });
+
+  test("leaves null-iterm_id pane alone (transient, waiting for self-stamp)", async () => {
+    store.createTab("eng", "trees");
+    store.createPane("oak", "eng"); // never bound
+    const terminal = makeTerminal([]);
+    const result = await reconcile(store, terminal);
+    expect(result.panesDeleted).toEqual([]);
+    expect(store.getPane("oak")).not.toBeNull();
   });
 
   test("keeps alive pane iterm_id", async () => {
@@ -161,6 +171,13 @@ describe("reconcile terminal session checks", () => {
     // But profile should still be applied (the heal applies even without rename)
     expect(result.profilesApplied.length).toBe(1);
     expect(result.profilesApplied[0].pane).toBe("paris");
+    // And the session title must be refreshed so iTerm shows the pane name,
+    // even though the pane wasn't renamed.
+    expect(
+      terminal.calls.setSessionName.some(
+        (c) => c.sessionId === "session-paris" && c.name === "Paris",
+      ),
+    ).toBe(true);
   });
 
   test("skips heal when pane has no iterm_id", async () => {
@@ -172,6 +189,8 @@ describe("reconcile terminal session checks", () => {
 
     expect(result.panesRenamed).toEqual([]);
     expect(result.profilesApplied).toEqual([]);
+    // Null iterm_id is transient (waiting for self-stamp) — pane is preserved.
+    expect(result.panesDeleted).toEqual([]);
     expect(store.getPane("test-east")).not.toBeNull();
   });
 

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -25,6 +25,7 @@ export type ReconcileResult = {
   dead: string[];
   orphans: ScreenSession[];
   panesCleared: string[];
+  panesDeleted: string[];
   tabsCleared: string[];
   tabsThemed: Array<{ tab: string; theme: string }>;
   panesThemed: Array<{ pane: string; theme: string }>;
@@ -62,14 +63,19 @@ export async function reconcile(
   );
 
   // --- Pane session check ---
+  // Pane lifecycle follows iTerm: if we confirm the pane's iTerm session is
+  // gone, delete the DB row (deletePane detaches any agent claiming it).
+  // Panes with null iterm_id are left alone — they're transient, waiting for
+  // self-stamp at MCP startup to bind them to a real iTerm session.
   const panesCleared: string[] = [];
+  const panesDeleted: string[] = [];
   if (terminal) {
     for (const pane of store.listPanes()) {
       if (!pane.iterm_id) continue;
       const isAlive = await terminal.isSessionAlive(pane.iterm_id).catch(() => false);
       if (!isAlive) {
-        store.clearPaneItermId(pane.name);
-        panesCleared.push(pane.name);
+        store.deletePane(pane.name);
+        panesDeleted.push(pane.name);
       }
     }
   }
@@ -154,6 +160,9 @@ export async function reconcile(
           badgeColor,
         });
         await terminal.setProfile(original.iterm_id, profileName);
+        // SetProfile switches profile attributes but leaves the session title untouched.
+        // Always set the session name so live iTerm UI matches the DB pane name.
+        await terminal.setSessionName(original.iterm_id, titleCase(workingName));
         profilesApplied.push({ pane: workingName, profile: profileName });
       } catch (e) {
         console.error(`[crew] reconcile: failed to apply profile for pane '${workingName}':`, e);
@@ -163,7 +172,7 @@ export async function reconcile(
 
   return {
     alive, dead, orphans,
-    panesCleared, tabsCleared,
+    panesCleared, panesDeleted, tabsCleared,
     tabsThemed, panesThemed,
     panesRenamed, profilesApplied,
   };
@@ -184,6 +193,9 @@ export function formatReport(result: ReconcileResult, agents: Agent[]): string {
   }
   if (result.panesCleared.length > 0) {
     lines.push(`${result.panesCleared.length} pane(s) with dead terminal session: ${result.panesCleared.join(", ")}`);
+  }
+  if (result.panesDeleted.length > 0) {
+    lines.push(`${result.panesDeleted.length} orphan pane(s) pruned: ${result.panesDeleted.join(", ")}`);
   }
   if (result.tabsCleared.length > 0) {
     lines.push(`${result.tabsCleared.length} tab(s) with dead terminal session: ${result.tabsCleared.join(", ")}`);


### PR DESCRIPTION
## Summary
- Session title refresh: `setSessionName` was only called on rename; panes already in the theme pool kept stale iTerm titles (e.g. 'Default Terminal' on Fondant's oak pane). Fix: always refresh after `setProfile`.
- Dead pane cleanup: when an iTerm session is confirmed dead, delete the pane row instead of nulling iterm_id. Pane lifecycle now follows iTerm. Null-iterm_id rows remain transient (awaiting self-stamp).

## Test plan
- [x] `bun test` — 49 passing
- [ ] Live test: restart Fondant, observe Oak pane gets title "Oak"
- [ ] Live test: close an iTerm pane, run `reconcile`, confirm DB row gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)