### PR TITLE
feat!: replace id/name params with generic env map; bump v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "1.3.5",
+  "version": "2.0.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -144,20 +144,26 @@ export async function startServer(): Promise<void> {
   const TOOLS = [
     {
       name: "agent_launch",
-      description: "Launch an agent in a persistent screen session (runs headless until attached to a pane)",
+      description: "Launch an agent in a persistent screen session (runs headless until attached to a pane). Identity and configuration flow through the env map; crew is a pure env-forwarder with no domain knowledge of what the vars mean.",
       inputSchema: {
         type: "object" as const,
         properties: {
-          id: { type: "string", description: "Agent ID (Wire agent name)" },
-          name: { type: "string", description: "Display name" },
-          plan: { type: "string", description: "Initial plan (shown on Wire dashboard)" },
-          prompt: { type: "string", description: "Initial prompt — the agent's task. Passed as positional arg to claude." },
+          env: {
+            type: "object",
+            additionalProperties: { type: "string" },
+            description:
+              "Env vars exported into the spawned agent's environment. " +
+              "MUST include AGENT_ID — crew uses it as the agent's primary identifier (screen session name, DB key). AGENT_NAME defaults to AGENT_ID. " +
+              "All other vars are opaque to crew. " +
+              "For Wire-using agents include AGENT_PRIVATE_KEY: orchestrator generates the keypair, pre-registers the public key on Wire (sponsoring-agent register flow), and passes the base64 PKCS8 private key here.",
+          },
+          prompt: { type: "string", description: "Initial prompt — passed as positional arg to the runtime command." },
           runtime: { type: "string", description: "Runtime: claude-code, codex, etc. Default: claude-code" },
-          project_dir: { type: "string", description: "Working directory for the agent" },
-          extra_flags: { type: "string", description: "Additional CLI flags" },
+          project_dir: { type: "string", description: "Working directory for the spawned process" },
+          extra_flags: { type: "string", description: "Additional CLI flags appended to the runtime command" },
           badge: { type: "string", description: "Badge text shown in pane top-right when attached (e.g. 'ENG-2998 Mochi')" },
         },
-        required: ["id", "name"],
+        required: ["env"],
       },
     },
     {
@@ -457,8 +463,7 @@ export async function startServer(): Promise<void> {
       switch (name) {
         case "agent_launch": {
           result = await orchestrator.launchAgent({
-            id: a.id as string,
-            displayName: a.name as string,
+            env: a.env as Record<string, string>,
             runtime: a.runtime as string | undefined,
             projectDir: a.project_dir as string | undefined,
             extraFlags: a.extra_flags as string | undefined,

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -1,0 +1,146 @@
+import { describe, test, expect, beforeEach, afterAll, mock } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import type { TerminalBackend } from "./terminal";
+
+// Capture the command passed to screen.createSession so we can assert on the
+// spawn-time env exports. Mock is installed before Orchestrator is imported.
+const createSessionCalls: Array<{ name: string; command: string }> = [];
+mock.module("./screen", () => ({
+  createSession: async (name: string, command: string) => {
+    createSessionCalls.push({ name, command });
+    return { name, pid: 12345 };
+  },
+  listSessions: async () => [],
+  getSessionPid: async () => null,
+  isAlive: async () => false,
+  detachSession: async () => {},
+  sendKeys: async () => {},
+  readOutput: async () => "",
+  killSession: async () => {},
+}));
+
+const { Orchestrator } = await import("./orchestrator");
+
+function makeTerminal(): TerminalBackend {
+  return {
+    name: "test",
+    currentSessionId: mock(async () => ""),
+    sessionIdForTty: mock(async () => null),
+    splitPane: mock(async () => ""),
+    splitSession: mock(async () => ""),
+    writeToSession: mock(async () => {}),
+    closeSession: mock(async () => {}),
+    isSessionAlive: mock(async () => true),
+    createTab: mock(async () => ""),
+    setSessionName: mock(async () => {}),
+    setBadge: mock(async () => {}),
+    flashSession: mock(async () => {}),
+    notifySession: mock(async () => {}),
+    renameWorkspace: mock(async () => {}),
+    writePaneProfile: mock(() => "Crew Test"),
+    deletePaneProfile: mock(() => {}),
+    setProfile: mock(async () => {}),
+    sendText: mock(async () => {}),
+  } as unknown as TerminalBackend;
+}
+
+let tmpDir: string;
+let dbPath: string;
+let orch: InstanceType<typeof Orchestrator>;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "orchestrator-test-"));
+  dbPath = join(tmpDir, "test.db");
+  orch = new Orchestrator(makeTerminal(), dbPath);
+  createSessionCalls.length = 0;
+});
+
+afterAll(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+describe("launchAgent env forwarding", () => {
+  test("AGENT_ID and AGENT_NAME flow through env, not separate params", async () => {
+    await orch.launchAgent({
+      env: { AGENT_ID: "test-agent", AGENT_NAME: "Test Agent" },
+    });
+
+    expect(createSessionCalls).toHaveLength(1);
+    const cmd = createSessionCalls[0]!.command;
+    expect(cmd).toContain("AGENT_ID='test-agent'");
+    expect(cmd).toContain("AGENT_NAME='Test Agent'");
+  });
+
+  test("throws when env.AGENT_ID is missing", async () => {
+    await expect(
+      orch.launchAgent({ env: {} }),
+    ).rejects.toThrow("env.AGENT_ID is required");
+  });
+
+  test("AGENT_NAME defaults to AGENT_ID when omitted", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "solo" } });
+
+    const cmd = createSessionCalls[0]!.command;
+    expect(cmd).toContain("AGENT_ID='solo'");
+    // DB record uses AGENT_ID as display name fallback
+    const agent = orch.store.getAgent("solo");
+    expect(agent?.display_name).toBe("solo");
+  });
+
+  test("exports AGENT_PRIVATE_KEY verbatim alongside identity vars", async () => {
+    await orch.launchAgent({
+      env: {
+        AGENT_ID: "waffles",
+        AGENT_NAME: "Waffles",
+        AGENT_PRIVATE_KEY: "MC4CAQAwBQYDK2VwBCIEtestkey",
+      },
+      prompt: "verify the deploy",
+    });
+
+    const cmd = createSessionCalls[0]!.command;
+    expect(cmd).toContain("AGENT_PRIVATE_KEY='MC4CAQAwBQYDK2VwBCIEtestkey'");
+    expect(cmd).toContain("AGENT_ID='waffles'");
+  });
+
+  test("exports arbitrary env vars without domain knowledge", async () => {
+    await orch.launchAgent({
+      env: { AGENT_ID: "test-agent", FOO: "bar", BAZ: "qux space" },
+    });
+
+    const cmd = createSessionCalls[0]!.command;
+    expect(cmd).toContain("FOO='bar'");
+    expect(cmd).toContain("BAZ='qux space'");
+  });
+
+  test("shell-escapes env values containing single quotes", async () => {
+    await orch.launchAgent({
+      env: { AGENT_ID: "test-agent", TRICKY: "it's a test" },
+    });
+
+    const cmd = createSessionCalls[0]!.command;
+    // shellEscape wraps in single quotes and escapes embedded ' as '\''
+    expect(cmd).toContain("TRICKY='it'\\''s a test'");
+  });
+
+  test("does not synthesize built-in env vars — orchestrator owns identity", async () => {
+    await orch.launchAgent({
+      env: { AGENT_ID: "test-agent" },
+    });
+
+    const cmd = createSessionCalls[0]!.command;
+    // Crew did NOT inject WIRE_URL or anything else the orchestrator didn't ask for
+    expect(cmd).not.toContain("WIRE_URL=");
+    expect(cmd).not.toContain("AGENT_PRIVATE_KEY=");
+  });
+
+  test("orchestrator can set WIRE_URL via env if needed", async () => {
+    await orch.launchAgent({
+      env: { AGENT_ID: "test-agent", WIRE_URL: "https://wire.example.com" },
+    });
+
+    const cmd = createSessionCalls[0]!.command;
+    expect(cmd).toContain("WIRE_URL='https://wire.example.com'");
+  });
+});

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -42,44 +42,52 @@ export class Orchestrator {
    * The agent runs in background — no pane attachment required.
    */
   async launchAgent(opts: {
-    id: string;
-    displayName: string;
+    /**
+     * Env vars exported into the spawned agent's process. Crew has no domain
+     * knowledge of what these mean — it just forwards them.
+     *
+     * MUST include AGENT_ID. Crew uses it as the agent's primary identifier
+     * (screen session name, DB record key, dedupe lookups). All other vars
+     * are opaque to crew. AGENT_NAME defaults to AGENT_ID if omitted.
+     *
+     * For Wire-using agents the orchestrator generates a keypair, pre-registers
+     * the public key on Wire (sponsoring-agent register flow), and includes
+     * the base64 PKCS8 private key as AGENT_PRIVATE_KEY here.
+     */
+    env: Record<string, string>;
     runtime?: string;
     projectDir?: string;
     extraFlags?: string;
-    privateKeyB64?: string;
-    /** Initial prompt — passed as positional arg to claude. */
+    /** Initial prompt — passed as positional arg to the runtime command. */
     prompt?: string;
     /** Optional badge text displayed in the pane's top-right when attached. */
     badge?: string;
   }): Promise<Agent> {
+    const id = opts.env.AGENT_ID;
+    if (!id) throw new Error("env.AGENT_ID is required");
+    const displayName = opts.env.AGENT_NAME ?? id;
+
     const runtime = opts.runtime ?? "claude-code";
-    let screenName = `${SCREEN_PREFIX}${opts.id}`;
+    let screenName = `${SCREEN_PREFIX}${id}`;
 
     // Check for existing agent with the same ID
-    const existing = this.store.getAgent(opts.id);
+    const existing = this.store.getAgent(id);
     if (existing) {
       const alive = await screen.isAlive(existing.screen_name);
       if (alive) {
         // During handoff, the old agent is still running.
         // Use a suffixed screen name to avoid collision.
-        screenName = `${SCREEN_PREFIX}${opts.id}-${Date.now()}`;
+        screenName = `${SCREEN_PREFIX}${id}-${Date.now()}`;
       } else {
         // Dead agent — clean up stale record
         this.store.deleteAgentByScreen(existing.screen_name);
       }
     }
 
-    // Build launch command with agent identity injected as env vars
-    const wireUrl = process.env.WIRE_URL ?? "http://localhost:9800";
+    // Build launch command. Template variables expand from env + PROJECT_DIR.
     const projectDir = opts.projectDir ?? process.cwd();
-    const vars = {
-      AGENT_ID: opts.id,
-      AGENT_NAME: opts.displayName,
-      WIRE_URL: wireUrl,
-      PROJECT_DIR: projectDir,
-    };
-    let command = getLaunchCommand(runtime, vars);
+    const templateVars = { ...opts.env, PROJECT_DIR: projectDir };
+    let command = getLaunchCommand(runtime, templateVars);
     if (opts.prompt) {
       command += ` ${shellEscape(opts.prompt)}`;
     }
@@ -87,9 +95,11 @@ export class Orchestrator {
       command += ` ${opts.extraFlags}`;
     }
 
-    // Set crew-specific identity + key vars
-    const keyExport = opts.privateKeyB64 ? ` CREW_PRIVATE_KEY=${shellEscape(opts.privateKeyB64)}` : "";
-    const envExports = `export AGENT_ID=${shellEscape(opts.id)} AGENT_NAME=${shellEscape(opts.displayName)} WIRE_URL=${shellEscape(wireUrl)}${keyExport}`;
+    // Forward env into the launched process. Verbatim — no synthesis, no
+    // built-ins. The orchestrator owns identity and config semantics.
+    const envExports = `export ${Object.entries(opts.env)
+      .map(([k, v]) => `${k}=${shellEscape(v)}`)
+      .join(" ")}`;
     const fullCommand = `cd ${shellEscape(projectDir)} && ${envExports} && ${command}`;
 
     // Create screen session
@@ -100,14 +110,14 @@ export class Orchestrator {
       try {
         await screen.sendKeys(screenName, "\n");
       } catch (e) {
-        console.error(`[crew] failed to auto-confirm dev-channel prompt for ${opts.id}:`, e);
+        console.error(`[crew] failed to auto-confirm dev-channel prompt for ${id}:`, e);
       }
     }, 3000);
 
     // Record in DB
     return this.store.createAgent({
-      id: opts.id,
-      display_name: opts.displayName,
+      id,
+      display_name: displayName,
       runtime,
       screen_name: screenName,
       screen_pid: session.pid,


### PR DESCRIPTION
Identity flows through `env: { AGENT_ID, AGENT_NAME, ... }` instead of separate `id`/`name` params. Crew becomes a pure env-forwarder. AGENT_ID is the only key crew reads (screen name, DB key); AGENT_NAME defaults to AGENT_ID. `privateKeyB64` and built-in synthesized exports removed.

Adds 8 smoke tests in src/orchestrator.test.ts to catch the kind of regression that snuck through 86dec2b (dead privateKeyB64 plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)