### PR TITLE
feat: ttl_idle_minutes + reaper + agent_list filters; v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -162,6 +162,11 @@ export async function startServer(): Promise<void> {
           project_dir: { type: "string", description: "Working directory for the spawned process" },
           extra_flags: { type: "string", description: "Additional CLI flags appended to the runtime command" },
           badge: { type: "string", description: "Badge text shown in pane top-right when attached (e.g. 'ENG-2998 Mochi')" },
+          ttl_idle_minutes: {
+            type: "number",
+            description:
+              "Optional idle TTL in minutes. If set, crew's reaper stops the agent once it has been idle (no agent_send / agent_attach / status update) for longer than this. Use for ephemeral spawns (e.g. indexing sidecars) that should self-clean rather than run forever.",
+          },
         },
         required: ["env"],
       },
@@ -206,8 +211,25 @@ export async function startServer(): Promise<void> {
     },
     {
       name: "agent_list",
-      description: "List all agents with status, pane, and runtime",
-      inputSchema: { type: "object" as const, properties: {} },
+      description:
+        "List agents with status, pane, and runtime. Optional filters narrow the result — useful when you only want attached agents (for routing) or headless ones (for cleanup). Dead agents are pruned by the boot-time reconciler, so the list only contains agents whose screen session was alive at last check.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          attached: {
+            type: "boolean",
+            description: "If true, return only agents attached to a pane. If false, return only headless agents. Omit for all.",
+          },
+          pane: {
+            type: "string",
+            description: "Return only agents attached to this exact pane.",
+          },
+          with_ttl: {
+            type: "boolean",
+            description: "If true, return only agents that have a ttl_idle_minutes set (ephemeral spawns). If false, return only agents without a TTL (permanent).",
+          },
+        },
+      },
     },
     {
       name: "agent_attach",
@@ -469,6 +491,7 @@ export async function startServer(): Promise<void> {
             extraFlags: a.extra_flags as string | undefined,
             prompt: a.prompt as string | undefined,
             badge: a.badge as string | undefined,
+            ttlIdleMinutes: a.ttl_idle_minutes as number | undefined,
           });
           break;
         }
@@ -492,9 +515,20 @@ export async function startServer(): Promise<void> {
           await orchestrator.stopAgent(a.id as string, a.cc_session_id as string | undefined);
           result = { stopped: a.id, cc_session_id: a.cc_session_id };
           break;
-        case "agent_list":
-          result = orchestrator.listAgents();
+        case "agent_list": {
+          let agents = orchestrator.listAgents();
+          if (typeof a.attached === "boolean") {
+            agents = agents.filter((ag) => (ag.pane !== null) === a.attached);
+          }
+          if (typeof a.pane === "string") {
+            agents = agents.filter((ag) => ag.pane === a.pane);
+          }
+          if (typeof a.with_ttl === "boolean") {
+            agents = agents.filter((ag) => (ag.ttl_idle_minutes !== null) === a.with_ttl);
+          }
+          result = agents;
           break;
+        }
         case "agent_attach":
           await orchestrator.attachAgent(a.id as string, a.pane as string);
           result = { attached: a.id, pane: a.pane };
@@ -658,5 +692,6 @@ export async function startServer(): Promise<void> {
 
   const report = await orchestrator.reconcile();
   console.error(`[crew] boot reconcile:\n${report}`);
+  orchestrator.startReaper();
   console.error(`[crew] ready (caller=${CALLER_AGENT_ID}, terminal=${terminalName}, cc_session=${ccSessionId ?? "unknown"})`);
 }

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -144,3 +144,69 @@ describe("launchAgent env forwarding", () => {
     expect(cmd).toContain("WIRE_URL='https://wire.example.com'");
   });
 });
+
+describe("idle TTL + reaper", () => {
+  test("ttlIdleMinutes is persisted on the agent row", async () => {
+    await orch.launchAgent({
+      env: { AGENT_ID: "ephemeral" },
+      ttlIdleMinutes: 60,
+    });
+    const agent = orch.store.getAgent("ephemeral");
+    expect(agent?.ttl_idle_minutes).toBe(60);
+  });
+
+  test("omitting ttlIdleMinutes leaves the column null (unreapable)", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "permanent" } });
+    const agent = orch.store.getAgent("permanent");
+    expect(agent?.ttl_idle_minutes).toBeNull();
+  });
+
+  test("reap() stops agents past their idle threshold", async () => {
+    await orch.launchAgent({
+      env: { AGENT_ID: "stale" },
+      ttlIdleMinutes: 30,
+    });
+    // Backdate last_seen so the agent looks 61 minutes idle.
+    orch.store["db"].prepare("UPDATE agents SET last_seen = ? WHERE id = ?")
+      .run(Date.now() - 61 * 60_000, "stale");
+
+    const reaped = await orch.reap();
+    expect(reaped).toContain("stale");
+    expect(orch.store.getAgent("stale")).toBeNull();
+  });
+
+  test("reap() leaves fresh agents alone", async () => {
+    await orch.launchAgent({
+      env: { AGENT_ID: "fresh" },
+      ttlIdleMinutes: 30,
+    });
+    const reaped = await orch.reap();
+    expect(reaped).not.toContain("fresh");
+    expect(orch.store.getAgent("fresh")).not.toBeNull();
+  });
+
+  test("reap() ignores agents without a ttl_idle_minutes", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "untracked" } });
+    orch.store["db"].prepare("UPDATE agents SET last_seen = ? WHERE id = ?")
+      .run(Date.now() - 24 * 60 * 60_000, "untracked");
+    const reaped = await orch.reap();
+    expect(reaped).not.toContain("untracked");
+    expect(orch.store.getAgent("untracked")).not.toBeNull();
+  });
+
+  test("agent_send bumps last_seen so TTL timer restarts on activity", async () => {
+    await orch.launchAgent({
+      env: { AGENT_ID: "active" },
+      ttlIdleMinutes: 5,
+    });
+    // Backdate last_seen
+    const staleTs = Date.now() - 10 * 60_000;
+    orch.store["db"].prepare("UPDATE agents SET last_seen = ? WHERE id = ?")
+      .run(staleTs, "active");
+
+    await orch.sendToAgent("active", "ping\n");
+
+    const fresh = orch.store.getAgent("active");
+    expect(fresh!.last_seen).toBeGreaterThan(staleTs);
+  });
+});

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -62,6 +62,13 @@ export class Orchestrator {
     prompt?: string;
     /** Optional badge text displayed in the pane's top-right when attached. */
     badge?: string;
+    /**
+     * Idle TTL in minutes. If set, the orchestrator's reaper (see
+     * {@link startReaper}) stops this agent once `now - last_seen`
+     * exceeds the threshold. `last_seen` is bumped on every send / attach /
+     * status update, so the timer restarts on real activity.
+     */
+    ttlIdleMinutes?: number;
   }): Promise<Agent> {
     const id = opts.env.AGENT_ID;
     if (!id) throw new Error("env.AGENT_ID is required");
@@ -122,6 +129,7 @@ export class Orchestrator {
       screen_name: screenName,
       screen_pid: session.pid,
       badge: opts.badge,
+      ttl_idle_minutes: opts.ttlIdleMinutes,
     });
   }
 
@@ -351,6 +359,7 @@ export class Orchestrator {
   async sendToAgent(agentId: string, text: string, ccSessionId?: string): Promise<void> {
     const agent = this.resolveAgent(agentId, ccSessionId);
     await screen.sendKeys(agent.screen_name, text);
+    this.store.touchAgent(agent.id);
   }
 
   /**
@@ -863,5 +872,50 @@ export class Orchestrator {
     const result = await reconcile(this.store, this.terminal);
     const agents = this.store.listAgents();
     return formatReport(result, agents);
+  }
+
+  // --- Reaper (idle TTL enforcement) ---
+
+  private reaperInterval: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * Scan agents with `ttl_idle_minutes` set and stop any whose
+   * `last_seen` is older than the threshold. Returns the IDs reaped.
+   */
+  async reap(): Promise<string[]> {
+    const now = Date.now();
+    const candidates = this.store.listAgentsWithTtl();
+    const reaped: string[] = [];
+    for (const agent of candidates) {
+      const ttlMs = (agent.ttl_idle_minutes ?? 0) * 60_000;
+      if (ttlMs <= 0) continue;
+      const idleMs = now - agent.last_seen;
+      if (idleMs <= ttlMs) continue;
+      try {
+        await this.stopAgent(agent.id, agent.cc_session_id ?? undefined);
+        reaped.push(agent.id);
+        console.error(
+          `[crew] reaper stopped '${agent.id}' (idle ${Math.round(idleMs / 60_000)}min > ttl ${agent.ttl_idle_minutes}min)`,
+        );
+      } catch (e) {
+        console.error(`[crew] reaper failed to stop '${agent.id}':`, e);
+      }
+    }
+    return reaped;
+  }
+
+  /** Start the reaper interval. Call once from a long-lived process. */
+  startReaper(intervalMs = 60_000): void {
+    if (this.reaperInterval) return;
+    this.reaperInterval = setInterval(() => {
+      this.reap().catch((e) => console.error(`[crew] reaper tick failed:`, e));
+    }, intervalMs);
+  }
+
+  stopReaper(): void {
+    if (this.reaperInterval) {
+      clearInterval(this.reaperInterval);
+      this.reaperInterval = null;
+    }
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -36,6 +36,7 @@ export type Agent = {
   badge: string | null;
   launched_at: number;
   last_seen: number;
+  ttl_idle_minutes: number | null;
 };
 
 export class CrewStore {
@@ -165,6 +166,15 @@ export class CrewStore {
         CREATE INDEX IF NOT EXISTS idx_agents_id ON agents(id);
       `);
     }
+
+    // Add ttl_idle_minutes column to agents if missing (v2.1.0 reaper).
+    // Runs AFTER the handoff rebuild so the column survives the table swap.
+    const hasTtl = this.db.prepare(
+      "SELECT * FROM pragma_table_info('agents') WHERE name='ttl_idle_minutes'"
+    ).get();
+    if (!hasTtl) {
+      this.db.exec("ALTER TABLE agents ADD COLUMN ttl_idle_minutes INTEGER");
+    }
   }
 
   // --- Tabs ---
@@ -259,15 +269,17 @@ export class CrewStore {
     cc_session_id?: string;
     pane?: string;
     badge?: string;
+    ttl_idle_minutes?: number;
   }): Agent {
     const now = Date.now();
     this.db.prepare(
-      `INSERT INTO agents (id, display_name, runtime, screen_name, screen_pid, cc_session_id, pane, badge, launched_at, last_seen)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO agents (id, display_name, runtime, screen_name, screen_pid, cc_session_id, pane, badge, launched_at, last_seen, ttl_idle_minutes)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       agent.id, agent.display_name, agent.runtime, agent.screen_name,
       agent.screen_pid ?? null, agent.cc_session_id ?? null,
       agent.pane ?? null, agent.badge ?? null, now, now,
+      agent.ttl_idle_minutes ?? null,
     );
     return {
       id: agent.id,
@@ -282,7 +294,19 @@ export class CrewStore {
       badge: agent.badge ?? null,
       launched_at: now,
       last_seen: now,
+      ttl_idle_minutes: agent.ttl_idle_minutes ?? null,
     };
+  }
+
+  setAgentTtl(id: string, minutes: number | null): void {
+    this.db.prepare("UPDATE agents SET ttl_idle_minutes = ? WHERE id = ?").run(minutes, id);
+  }
+
+  /** List agents that have a TTL set — used by the reaper. */
+  listAgentsWithTtl(): Agent[] {
+    return this.db.prepare(
+      "SELECT * FROM agents WHERE ttl_idle_minutes IS NOT NULL"
+    ).all() as Agent[];
   }
 
   setAgentBadge(id: string, badge: string | null): void {


### PR DESCRIPTION
## Summary

- `ttl_idle_minutes` on agents + background reaper — kills stale spawns instead of relying on unenforceable prompt-level idle-timeout instructions
- `agent_list` gains optional filters (attached / pane / with_ttl) so callers can narrow to the agents they care about
- Closes the class of failure in knowledge-indexer-tools#1

## Test plan

- [x] Existing test suite passes (44 prior + 6 new = 50; 0 fail)
- [ ] Smoke: spawn an agent with \`ttl_idle_minutes: 1\`, watch reaper stop it on the next tick
- [ ] Consumers (knowledge-indexer-tools, knowledge-indexer-claude-code) bumped to pin v2.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)