### PR TITLE
fix: registerAgent refuses id mismatch; v2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -7,6 +7,7 @@ import type { TerminalBackend } from "./terminal";
 // Capture the command passed to screen.createSession so we can assert on the
 // spawn-time env exports. Mock is installed before Orchestrator is imported.
 const createSessionCalls: Array<{ name: string; command: string }> = [];
+const screenState = { isAliveResult: false };
 mock.module("./screen", () => ({
   createSession: async (name: string, command: string) => {
     createSessionCalls.push({ name, command });
@@ -14,7 +15,7 @@ mock.module("./screen", () => ({
   },
   listSessions: async () => [],
   getSessionPid: async () => null,
-  isAlive: async () => false,
+  isAlive: async () => screenState.isAliveResult,
   detachSession: async () => {},
   sendKeys: async () => {},
   readOutput: async () => "",
@@ -208,5 +209,30 @@ describe("idle TTL + reaper", () => {
 
     const fresh = orch.store.getAgent("active");
     expect(fresh!.last_seen).toBeGreaterThan(staleTs);
+  });
+});
+
+describe("registerAgent id-mismatch safety", () => {
+  test("throws when caller id doesn't match the agent owning the screen", async () => {
+    // Simulate Brioche running in screen 'wire-brioche' with an existing row
+    await orch.launchAgent({ env: { AGENT_ID: "brioche", AGENT_NAME: "Brioche" } });
+
+    const prevSty = process.env.STY;
+    process.env.STY = "99999.wire-brioche";
+    screenState.isAliveResult = true;
+    try {
+      await expect(
+        orch.registerAgent({ id: "danish", displayName: "Danish" }),
+      ).rejects.toThrow(/owned by agent 'brioche' but called with id='danish'/);
+
+      // Brioche's row must be untouched
+      const row = orch.store.getAgent("brioche");
+      expect(row).not.toBeNull();
+      expect(row!.cc_session_id).toBeNull();
+    } finally {
+      if (prevSty === undefined) delete process.env.STY;
+      else process.env.STY = prevSty;
+      screenState.isAliveResult = false;
+    }
   });
 });

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -175,6 +175,22 @@ export class Orchestrator {
     // Check if this exact screen session is already registered
     const existingByScreen = this.store.getAgentByScreen(screenName);
     if (existingByScreen) {
+      // Safety: refuse if the caller is trying to register under an id that
+      // doesn't match the agent that OWNS this screen session. Without this,
+      // Brioche calling registerAgent({id:'danish'}) from her own screen
+      // would overwrite her own DB row's cc_session_id with Danish's id —
+      // silently corrupting her identity record. STY is the ground truth
+      // for "who is running in this process"; opts.id must agree with it.
+      if (existingByScreen.id !== opts.id) {
+        throw new Error(
+          `registerAgent: screen '${screenName}' is owned by agent ` +
+          `'${existingByScreen.id}' but called with id='${opts.id}'. ` +
+          `STY identifies the running process — you can only register ` +
+          `yourself. If you want to register a DIFFERENT agent (e.g. one ` +
+          `you spawned), call agent_register from inside that agent's ` +
+          `own screen session, not yours.`,
+        );
+      }
       this.store.updateAgentPid(existingByScreen.id, screenPid);
       if (ccSessionId) this.store.updateAgentCcSession(screenName, ccSessionId);
       if (!existingByScreen.pane && callerPane) {


### PR DESCRIPTION
Patch for a silent data-corruption bug Brioche hit manually recovering Danish. See #40 for the surrounding agent_resume design discussion.

Tested: 70 pass / 0 fail (one new case covering the safety throw).