### PR TITLE
fix: badge cleanup on stop + detached-screen auto-link fix; v2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -173,7 +173,15 @@ export async function startServer(): Promise<void> {
     },
     {
       name: "agent_badge",
-      description: "Update an agent's badge text. The badge appears in the top-right of the pane when the agent is attached. Color is determined by the pane's theme.",
+      description:
+        "Set an agent's badge. Writes the text to the agent's DB row AND, " +
+        "if the agent is currently attached to a pane, pushes the text to " +
+        "that pane's iTerm2/cmux overlay immediately. This is the single " +
+        "call you should reach for when you want a badge to appear — no " +
+        "need to also call pane_badge. " +
+        "On subsequent agent_attach, the saved badge is re-rendered " +
+        "automatically. On agent_detach or agent_stop, the pane's badge is " +
+        "cleared. Badge color is determined by the pane's theme profile.",
       inputSchema: {
         type: "object" as const,
         properties: {
@@ -384,7 +392,15 @@ export async function startServer(): Promise<void> {
     },
     {
       name: "pane_badge",
-      description: "Set a badge/status on a pane (overlay text in corner for iTerm2, sidebar status for cmux)",
+      description:
+        "Set a badge on a pane directly, bypassing any agent that may be " +
+        "attached. Use this for pane-purpose labels on panes that don't " +
+        "currently host an agent (e.g., an empty pane reserved for a future " +
+        "role, a tab-metadata slot). For agent-identity badges, prefer " +
+        "agent_badge — it writes the DB and auto-renders when the agent " +
+        "attaches, and it survives detach/reattach cycles. A badge set via " +
+        "pane_badge is transient — an agent attaching to the pane will " +
+        "overwrite it with its own badge.",
       inputSchema: {
         type: "object" as const,
         properties: {

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -7,7 +7,7 @@ import type { TerminalBackend } from "./terminal";
 // Capture the command passed to screen.createSession so we can assert on the
 // spawn-time env exports. Mock is installed before Orchestrator is imported.
 const createSessionCalls: Array<{ name: string; command: string }> = [];
-const screenState = { isAliveResult: false };
+const screenState = { isAliveResult: false, isAttachedResult: false };
 mock.module("./screen", () => ({
   createSession: async (name: string, command: string) => {
     createSessionCalls.push({ name, command });
@@ -16,6 +16,7 @@ mock.module("./screen", () => ({
   listSessions: async () => [],
   getSessionPid: async () => null,
   isAlive: async () => screenState.isAliveResult,
+  isAttached: async () => screenState.isAttachedResult,
   detachSession: async () => {},
   sendKeys: async () => {},
   readOutput: async () => "",

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -164,8 +164,18 @@ export class Orchestrator {
 
     // Find the pane this agent is sitting in (by terminal session ID).
     // If the session isn't registered as a pane, auto-register it.
+    //
+    // IMPORTANT: only auto-link when the screen is actually attached to a
+    // terminal right now. A detached screen has no iTerm pane of its own —
+    // callerSessionId may still be set (inherited from the shell that ran
+    // `screen -dmS`), but that shell's pane is not where this agent lives.
+    // Example breakage: Brioche (in lisbon) runs `screen -dmS wire-danish`;
+    // Danish's inherited ITERM_SESSION_ID points at lisbon; if we auto-link,
+    // Danish ends up with pane='lisbon' (Brioche's pane). Skip auto-link
+    // for detached screens — the caller can agent_attach explicitly later.
     let callerPane: string | null = null;
-    if (opts.callerSessionId) {
+    const attached = await screen.isAttached(screenName);
+    if (opts.callerSessionId && attached) {
       callerPane = this.store.listPanes().find((p) => p.iterm_id === opts.callerSessionId)?.name ?? null;
       if (!callerPane) {
         callerPane = await this.autoRegisterPane(opts.callerSessionId);
@@ -222,6 +232,17 @@ export class Orchestrator {
     } else {
       agent = this.store.getAgent(id);
       if (!agent) throw new Error(`agent '${id}' not found`);
+    }
+
+    // Clear the pane's badge before killing — otherwise the dead agent's
+    // badge text lingers on the now-empty pane until something else clobbers
+    // it. Matches the agent_badge/attach/detach convention of "the agent
+    // owns the pane's badge slot while it's attached."
+    if (agent.pane) {
+      const pane = this.store.getPane(agent.pane);
+      if (pane?.iterm_id) {
+        try { await this.terminal.setBadge(pane.iterm_id, ""); } catch {}
+      }
     }
 
     await screen.killSession(agent.screen_name);

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -84,6 +84,30 @@ export async function getSessionPid(name: string): Promise<number | null> {
 }
 
 /**
+ * Check whether a screen session is currently attached to a terminal.
+ * Returns false for detached-but-alive sessions and for sessions that
+ * don't exist. Used by registerAgent to avoid auto-linking a headless
+ * agent to a pane — a detached screen has no iTerm session of its own
+ * and any ITERM_SESSION_ID env it sees is inherited from whoever ran
+ * `screen -dmS`, not where it's actually displayed.
+ */
+export async function isAttached(name: string): Promise<boolean> {
+  try {
+    const result = await $`${SCREEN} -ls`.quiet().nothrow();
+    const output = result.stdout.toString();
+    for (const line of output.split("\n")) {
+      const match = line.match(/^\t(\d+)\.(\S+)\t.*\((Attached|Detached)\)/);
+      if (match && match[2] === name) {
+        return match[3] === "Attached";
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Check if a screen session is alive.
  */
 export async function isAlive(name: string): Promise<boolean> {


### PR DESCRIPTION
Two small bugs surfaced by Brioche's manual Danish recovery:
1. `agent_stop` leaves pane badge visible (now clears before kill)
2. Self-register auto-links to caller's pane when screen is detached (now checks screen.isAttached first)

Also tightens MCP tool descriptions for agent_badge / pane_badge to make the one-call pattern explicit. Addresses Brioche seq 3175 (badge-API unification) + #40 gotcha #3.

Tests: 70 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)