### PR TITLE
feat: agent_resume — deterministic stopped-agent recovery; v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -192,6 +192,42 @@ export async function startServer(): Promise<void> {
       },
     },
     {
+      name: "agent_resume",
+      description:
+        "Resume a stopped agent whose Claude Code session JSONL is still " +
+        "on disk. Starts a new screen session running `claude --resume " +
+        "<cc_session_id>` with the provided env and channels, seeds the " +
+        "DB row from the inputs (no self-register dance required), and " +
+        "optionally attaches to a pane. Use when agent_stop was premature " +
+        "and you want the agent back with its conversation history intact. " +
+        "The session JSONL is stored at " +
+        "`~/.claude/projects/<encoded-project-dir>/<cc_session_id>.jsonl`.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          id: { type: "string", description: "Agent ID to resume (the id it was running under before agent_stop)." },
+          cc_session_id: { type: "string", description: "Claude Code session ID — the JSONL filename stem under ~/.claude/projects/<cwd>/. Required in v1 (auto-detection planned)." },
+          project_dir: { type: "string", description: "Working directory the original agent was launched in. Claude resumes the matching session from ~/.claude/projects/<encoded-cwd>/." },
+          env: {
+            type: "object",
+            additionalProperties: { type: "string" },
+            description: "Env to export into the resumed process. Mirrors agent_launch semantics. Must include AGENT_ID matching `id`.",
+          },
+          channels: {
+            type: "array",
+            items: { type: "string" },
+            description: "Dev-channel plugin list (e.g. ['plugin:wire@agiterra', 'plugin:wire-ipc@agiterra']). Defaults to just wire. Explicit list sidesteps the --resume/--dangerously-load-development-channels argparser conflict.",
+          },
+          extra_flags: { type: "string", description: "Additional CLI flags appended after --resume." },
+          attach_to_pane: { type: "string", description: "Optional pane name to attach the resumed agent to once the screen is up. Badge auto-renders on attach." },
+          display_name: { type: "string", description: "Display name. Defaults to env.AGENT_NAME or id." },
+          badge: { type: "string", description: "Badge text written to the agent's DB row; rendered on the pane if attach_to_pane is set." },
+          runtime: { type: "string", description: "Runtime. Only 'claude-code' is supported in v1." },
+        },
+        required: ["id", "cc_session_id", "project_dir"],
+      },
+    },
+    {
       name: "agent_register",
       description: "Register yourself as a crew agent. Call this on boot if you're running in a screen session. Auto-links to your pane if one exists with the same name.",
       inputSchema: {
@@ -508,6 +544,21 @@ export async function startServer(): Promise<void> {
             prompt: a.prompt as string | undefined,
             badge: a.badge as string | undefined,
             ttlIdleMinutes: a.ttl_idle_minutes as number | undefined,
+          });
+          break;
+        }
+        case "agent_resume": {
+          result = await orchestrator.resumeAgent({
+            id: a.id as string,
+            ccSessionId: a.cc_session_id as string,
+            projectDir: a.project_dir as string,
+            env: a.env as Record<string, string> | undefined,
+            channels: a.channels as string[] | undefined,
+            extraFlags: a.extra_flags as string | undefined,
+            attachToPane: a.attach_to_pane as string | undefined,
+            displayName: a.display_name as string | undefined,
+            badge: a.badge as string | undefined,
+            runtime: a.runtime as string | undefined,
           });
           break;
         }

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -213,6 +213,71 @@ describe("idle TTL + reaper", () => {
   });
 });
 
+describe("resumeAgent", () => {
+  test("builds a claude --resume command with explicit channels list", async () => {
+    await orch.resumeAgent({
+      id: "danish",
+      ccSessionId: "7cc4b34e-225b-42ed-b2e3-bafa696cfc70",
+      projectDir: "/tmp/danish-wd",
+      channels: ["plugin:wire@agiterra", "plugin:knowledge@agiterra"],
+      env: { AGENT_PRIVATE_KEY: "k" },
+    });
+
+    expect(createSessionCalls).toHaveLength(1);
+    const cmd = createSessionCalls[0]!.command;
+    // explicit channels list sidesteps the --resume positional-arg conflict
+    expect(cmd).toContain("--dangerously-load-development-channels 'plugin:wire@agiterra,plugin:knowledge@agiterra'");
+    expect(cmd).toContain("--resume '7cc4b34e-225b-42ed-b2e3-bafa696cfc70'");
+    expect(cmd).toContain("cd '/tmp/danish-wd'");
+    expect(cmd).toContain("AGENT_ID='danish'");
+    expect(cmd).toContain("AGENT_PRIVATE_KEY='k'");
+  });
+
+  test("pre-seeds the DB row from inputs (no self-register required)", async () => {
+    await orch.resumeAgent({
+      id: "galette",
+      ccSessionId: "fake-session-id",
+      projectDir: "/tmp/galette-wd",
+      displayName: "Galette",
+      badge: "ENG-3020 Galette",
+    });
+
+    const agent = orch.store.getAgent("galette");
+    expect(agent).not.toBeNull();
+    expect(agent!.cc_session_id).toBe("fake-session-id");
+    expect(agent!.display_name).toBe("Galette");
+    expect(agent!.badge).toBe("ENG-3020 Galette");
+    expect(agent!.screen_name).toBe("wire-galette");
+  });
+
+  test("throws if agent is already alive", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "already-running" } });
+    screenState.isAliveResult = true;
+    try {
+      await expect(
+        orch.resumeAgent({
+          id: "already-running",
+          ccSessionId: "x",
+          projectDir: "/tmp",
+        }),
+      ).rejects.toThrow(/already running/);
+    } finally {
+      screenState.isAliveResult = false;
+    }
+  });
+
+  test("rejects env.AGENT_ID mismatch", async () => {
+    await expect(
+      orch.resumeAgent({
+        id: "alpha",
+        ccSessionId: "s",
+        projectDir: "/tmp",
+        env: { AGENT_ID: "beta" },
+      }),
+    ).rejects.toThrow(/does not match env\.AGENT_ID/);
+  });
+});
+
 describe("registerAgent id-mismatch safety", () => {
   test("throws when caller id doesn't match the agent owning the screen", async () => {
     // Simulate Brioche running in screen 'wire-brioche' with an existing row

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -134,6 +134,123 @@ export class Orchestrator {
   }
 
   /**
+   * Resume a stopped agent whose Claude Code session JSONL still exists.
+   *
+   * Mirrors {@link launchAgent} but passes `--resume <ccSessionId>` to the
+   * runtime so the agent picks up its conversation history, and pre-seeds
+   * the DB row with everything the caller tells us (id, cc_session_id,
+   * optional pane) rather than relying on the resumed agent to
+   * self-register from inside.
+   *
+   * Why this exists: premature agent_stop is irreversible today — the DB
+   * row is gone and recreating it by hand is ~10 non-obvious steps
+   * (see crew-tools#40). This collapses recovery into one call for the
+   * common case where the JSONL is still on disk.
+   *
+   * Channels handling: Claude Code's argparser treats positionals after
+   * --dangerously-load-development-channels as part of the channel list,
+   * which collides with --resume. We always pass an explicit channels
+   * list to sidestep that. The default list is the runtime default's
+   * channel; override via opts.channels for fuller plugin loads.
+   */
+  async resumeAgent(opts: {
+    /** Agent ID to resume. Must not already be alive. */
+    id: string;
+    /** Claude Code session ID (the JSONL filename stem). */
+    ccSessionId: string;
+    /** Working directory for the resumed process. */
+    projectDir: string;
+    /** Optional env — mirrors launchAgent semantics. */
+    env?: Record<string, string>;
+    /** Dev-channel plugin list. Defaults to ["plugin:wire@agiterra"]. */
+    channels?: string[];
+    /** Runtime name. Default: claude-code. */
+    runtime?: string;
+    /** Display name. Defaults to env.AGENT_NAME or opts.id. */
+    displayName?: string;
+    /** Additional CLI flags appended after --resume. */
+    extraFlags?: string;
+    /** Optional pane to attach to once the resumed screen is up. */
+    attachToPane?: string;
+    /** Optional badge text — forwarded to agent record + pane on attach. */
+    badge?: string;
+  }): Promise<Agent> {
+    if (opts.runtime && opts.runtime !== "claude-code") {
+      throw new Error(`resumeAgent only supports claude-code today (got '${opts.runtime}')`);
+    }
+    const runtime = opts.runtime ?? "claude-code";
+
+    // Refuse to double-resume
+    const existing = this.store.getAgent(opts.id);
+    if (existing) {
+      const alive = await screen.isAlive(existing.screen_name);
+      if (alive) {
+        throw new Error(
+          `resumeAgent: agent '${opts.id}' is already running (screen '${existing.screen_name}'). ` +
+          `Stop it first with agent_stop or use agent_attach to view it.`,
+        );
+      }
+      // Dead row left behind — prune it so createAgent doesn't collide.
+      this.store.deleteAgentByScreen(existing.screen_name);
+    }
+
+    const env: Record<string, string> = { ...(opts.env ?? {}), AGENT_ID: opts.id };
+    if (opts.env?.AGENT_ID && opts.env.AGENT_ID !== opts.id) {
+      throw new Error(`resumeAgent: opts.id ('${opts.id}') does not match env.AGENT_ID ('${opts.env.AGENT_ID}')`);
+    }
+    const displayName = opts.displayName ?? env.AGENT_NAME ?? opts.id;
+    const screenName = `${SCREEN_PREFIX}${opts.id}`;
+    const channels = (opts.channels ?? ["plugin:wire@agiterra"]).join(",");
+
+    // Build: claude --dangerously-load-development-channels <channels> \
+    //        --permission-mode bypassPermissions --resume <cc_session_id> [extra]
+    // Explicit channels list sidesteps the --resume positional-arg conflict.
+    let command =
+      `claude --dangerously-load-development-channels ${shellEscape(channels)} ` +
+      `--permission-mode bypassPermissions --resume ${shellEscape(opts.ccSessionId)}`;
+    if (opts.extraFlags) command += ` ${opts.extraFlags}`;
+
+    const envExports = `export ${Object.entries(env)
+      .map(([k, v]) => `${k}=${shellEscape(v)}`)
+      .join(" ")}`;
+    const fullCommand = `cd ${shellEscape(opts.projectDir)} && ${envExports} && ${command}`;
+
+    const session = await screen.createSession(screenName, fullCommand);
+
+    // Auto-confirm dev-channel prompt (same cadence as launchAgent).
+    setTimeout(async () => {
+      try {
+        await screen.sendKeys(screenName, "\n");
+      } catch (e) {
+        console.error(`[crew] failed to auto-confirm dev-channel prompt for resumed '${opts.id}':`, e);
+      }
+    }, 3000);
+
+    // Seed the DB row directly from what the caller told us — no need to
+    // wait for the resumed agent to self-register (and no risk of the
+    // callerSessionId trap biting; we have no callerSessionId here).
+    const created = this.store.createAgent({
+      id: opts.id,
+      display_name: displayName,
+      runtime,
+      screen_name: screenName,
+      screen_pid: session.pid,
+      cc_session_id: opts.ccSessionId,
+      pane: undefined,
+      badge: opts.badge,
+    });
+
+    // If the caller wants the resumed agent visible, attach now. attachAgent
+    // will re-render the badge on the pane per the badge-slot convention.
+    if (opts.attachToPane) {
+      await this.attachAgent(opts.id, opts.attachToPane);
+      return this.store.getAgent(opts.id) ?? created;
+    }
+
+    return created;
+  }
+
+  /**
    * Register an already-running agent (self-registration).
    * The agent detects its own screen session from STY env var.
    * If callerSessionId is provided, auto-links to the pane owning that session.


### PR DESCRIPTION
One-call recovery for agents agent_stop'd prematurely (Brioche's Danish/Galette scenario). Seeds DB from inputs, avoids the self-register-then-fix-pane workaround dance.

Tests: 74 pass (4 new). Ref crew-tools#40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)