### PR TITLE
feat: persistent spawn manifests + tombstones, single-arg agent_resume; v2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -194,37 +194,59 @@ export async function startServer(): Promise<void> {
     {
       name: "agent_resume",
       description:
-        "Resume a stopped agent whose Claude Code session JSONL is still " +
-        "on disk. Starts a new screen session running `claude --resume " +
-        "<cc_session_id>` with the provided env and channels, seeds the " +
-        "DB row from the inputs (no self-register dance required), and " +
-        "optionally attaches to a pane. Use when agent_stop was premature " +
-        "and you want the agent back with its conversation history intact. " +
-        "The session JSONL is stored at " +
-        "`~/.claude/projects/<encoded-project-dir>/<cc_session_id>.jsonl`.",
+        "Resume a stopped agent from its tombstone. Since v2.3.0, every " +
+        "agent_launch persists a spawn manifest (project_dir, env, channels, " +
+        "badge, ttl_idle_minutes, …). agent_stop copies that manifest into a " +
+        "tombstone row. Calling agent_resume({ id }) looks up the most " +
+        "recent tombstone for that id and reconstructs the spawn with one " +
+        "call — no re-supplying inputs.\n\n" +
+        "Wire identity: AGENT_PRIVATE_KEY is stripped from the stored " +
+        "manifest, so if the agent uses Wire, first call " +
+        "`register_agent` (from wire-ipc) to rotate the keypair on Wire, " +
+        "then pass the new key as `env.AGENT_PRIVATE_KEY` here. Wire's " +
+        "/agents/register is UPSERT keyed on id, so the same agent id " +
+        "continues to exist with a new pubkey.\n\n" +
+        "Any explicit field overrides the tombstone's value (including " +
+        "cc_session_id and project_dir — useful for resuming into a " +
+        "different worktree).",
       inputSchema: {
         type: "object" as const,
         properties: {
           id: { type: "string", description: "Agent ID to resume (the id it was running under before agent_stop)." },
-          cc_session_id: { type: "string", description: "Claude Code session ID — the JSONL filename stem under ~/.claude/projects/<cwd>/. Required in v1 (auto-detection planned)." },
-          project_dir: { type: "string", description: "Working directory the original agent was launched in. Claude resumes the matching session from ~/.claude/projects/<encoded-cwd>/." },
+          cc_session_id: { type: "string", description: "Claude Code session ID — the JSONL filename stem. If omitted, falls back to the tombstone's cc_session_id (the session that was live when the agent was stopped)." },
+          project_dir: { type: "string", description: "Working directory. Defaults to the tombstone manifest's project_dir." },
           env: {
             type: "object",
             additionalProperties: { type: "string" },
-            description: "Env to export into the resumed process. Mirrors agent_launch semantics. Must include AGENT_ID matching `id`.",
+            description: "Env overrides, merged on top of the tombstone's sanitized env. AGENT_PRIVATE_KEY is never in the tombstone — supply it here for Wire-using agents.",
           },
           channels: {
             type: "array",
             items: { type: "string" },
-            description: "Dev-channel plugin list (e.g. ['plugin:wire@agiterra', 'plugin:wire-ipc@agiterra']). Defaults to just wire. Explicit list sidesteps the --resume/--dangerously-load-development-channels argparser conflict.",
+            description: "Dev-channel plugin list. Overrides the tombstone's recorded list; falls back to ['plugin:wire@agiterra'].",
           },
-          extra_flags: { type: "string", description: "Additional CLI flags appended after --resume." },
-          attach_to_pane: { type: "string", description: "Optional pane name to attach the resumed agent to once the screen is up. Badge auto-renders on attach." },
-          display_name: { type: "string", description: "Display name. Defaults to env.AGENT_NAME or id." },
-          badge: { type: "string", description: "Badge text written to the agent's DB row; rendered on the pane if attach_to_pane is set." },
-          runtime: { type: "string", description: "Runtime. Only 'claude-code' is supported in v1." },
+          extra_flags: { type: "string", description: "Additional CLI flags appended after --resume. Defaults to tombstone's extra_flags." },
+          attach_to_pane: { type: "string", description: "Optional pane to attach the resumed agent to once the screen is up." },
+          display_name: { type: "string", description: "Display name. Defaults to tombstone's display_name." },
+          badge: { type: "string", description: "Badge text. Defaults to tombstone's badge." },
+          runtime: { type: "string", description: "Runtime. Defaults to tombstone's runtime. Only 'claude-code' is supported today." },
         },
-        required: ["id", "cc_session_id", "project_dir"],
+        required: ["id"],
+      },
+    },
+    {
+      name: "tombstone_list",
+      description:
+        "List tombstones (stopped-agent records) with their manifests. " +
+        "Useful for discovering what's resumable. Without `id`, returns " +
+        "the most recent tombstones across all agents; with `id`, returns " +
+        "all tombstones for that agent, most recent first.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          id: { type: "string", description: "Filter by agent id." },
+          limit: { type: "number", description: "Max rows (default 50)." },
+        },
       },
     },
     {
@@ -550,8 +572,8 @@ export async function startServer(): Promise<void> {
         case "agent_resume": {
           result = await orchestrator.resumeAgent({
             id: a.id as string,
-            ccSessionId: a.cc_session_id as string,
-            projectDir: a.project_dir as string,
+            ccSessionId: a.cc_session_id as string | undefined,
+            projectDir: a.project_dir as string | undefined,
             env: a.env as Record<string, string> | undefined,
             channels: a.channels as string[] | undefined,
             extraFlags: a.extra_flags as string | undefined,
@@ -560,6 +582,13 @@ export async function startServer(): Promise<void> {
             badge: a.badge as string | undefined,
             runtime: a.runtime as string | undefined,
           });
+          break;
+        }
+        case "tombstone_list": {
+          result = orchestrator.store.listTombstones(
+            a.id as string | undefined,
+            a.limit as number | undefined,
+          );
           break;
         }
         case "agent_register":

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -213,6 +213,58 @@ describe("idle TTL + reaper", () => {
   });
 });
 
+describe("spawn manifest + tombstones", () => {
+  test("launchAgent persists a manifest stripped of AGENT_PRIVATE_KEY", async () => {
+    await orch.launchAgent({
+      env: {
+        AGENT_ID: "danish",
+        AGENT_NAME: "Danish",
+        AGENT_PRIVATE_KEY: "secret-key-base64",
+        KNOWLEDGE_ENRICH_RULES: '{"ipc":{"from":["brioche"]}}',
+      },
+      projectDir: "/tmp/danish-wd",
+      prompt: "Run the ENG-3021 audit.",
+      badge: "ENG-3021 Danish",
+      ttlIdleMinutes: 60,
+    });
+
+    const row = orch.store.getAgent("danish");
+    expect(row?.spawn_manifest).not.toBeNull();
+    const manifest = JSON.parse(row!.spawn_manifest!);
+    expect(manifest.env.AGENT_ID).toBe("danish");
+    expect(manifest.env.AGENT_NAME).toBe("Danish");
+    expect(manifest.env.KNOWLEDGE_ENRICH_RULES).toBe('{"ipc":{"from":["brioche"]}}');
+    expect(manifest.env.AGENT_PRIVATE_KEY).toBeUndefined();
+    expect(manifest.project_dir).toBe("/tmp/danish-wd");
+    expect(manifest.prompt).toBe("Run the ENG-3021 audit.");
+    expect(manifest.badge).toBe("ENG-3021 Danish");
+    expect(manifest.ttl_idle_minutes).toBe(60);
+  });
+
+  test("stopAgent writes a tombstone and deletes the live row", async () => {
+    await orch.launchAgent({
+      env: { AGENT_ID: "galette" },
+      projectDir: "/tmp/galette",
+      badge: "ENG-3020",
+    });
+    screenState.isAliveResult = true;
+    try {
+      await orch.stopAgent("galette");
+    } finally {
+      screenState.isAliveResult = false;
+    }
+
+    expect(orch.store.getAgent("galette")).toBeNull();
+    const tomb = orch.store.getLatestTombstone("galette");
+    expect(tomb).not.toBeNull();
+    expect(tomb!.id).toBe("galette");
+    expect(tomb!.badge).toBe("ENG-3020");
+    expect(tomb!.spawn_manifest).not.toBeNull();
+    const manifest = JSON.parse(tomb!.spawn_manifest!);
+    expect(manifest.project_dir).toBe("/tmp/galette");
+  });
+});
+
 describe("resumeAgent", () => {
   test("builds a claude --resume command with explicit channels list", async () => {
     await orch.resumeAgent({
@@ -275,6 +327,63 @@ describe("resumeAgent", () => {
         env: { AGENT_ID: "beta" },
       }),
     ).rejects.toThrow(/does not match env\.AGENT_ID/);
+  });
+
+  test("single-arg resume pulls cc_session_id + project_dir from tombstone", async () => {
+    // Launch, stop, then resume with JUST id.
+    await orch.launchAgent({
+      env: { AGENT_ID: "ghost", AGENT_NAME: "Ghost", KNOWLEDGE_ENRICH_RULES: "{}" },
+      projectDir: "/tmp/ghost-wd",
+      badge: "Ghost in the shell",
+    });
+    // Fake the cc_session_id so the tombstone carries a real one.
+    orch.store["db"].prepare("UPDATE agents SET cc_session_id = ? WHERE id = ?")
+      .run("cc-session-ghost", "ghost");
+    screenState.isAliveResult = true;
+    try { await orch.stopAgent("ghost"); } finally { screenState.isAliveResult = false; }
+    createSessionCalls.length = 0;
+
+    const resumed = await orch.resumeAgent({ id: "ghost" });
+
+    // Spawn command pulls the tombstone's cc_session_id + project_dir
+    expect(createSessionCalls).toHaveLength(1);
+    const cmd = createSessionCalls[0]!.command;
+    expect(cmd).toContain("cd '/tmp/ghost-wd'");
+    expect(cmd).toContain("--resume 'cc-session-ghost'");
+    expect(cmd).toContain("AGENT_NAME='Ghost'");
+    expect(cmd).toContain("KNOWLEDGE_ENRICH_RULES='{}'");
+
+    // Resumed row inherits identity defaults from the tombstone
+    expect(resumed.display_name).toBe("Ghost");
+    expect(resumed.badge).toBe("Ghost in the shell");
+    expect(resumed.cc_session_id).toBe("cc-session-ghost");
+  });
+
+  test("resume env overrides are merged on top of tombstone env", async () => {
+    await orch.launchAgent({
+      env: { AGENT_ID: "merge", FROM_MANIFEST: "original" },
+      projectDir: "/tmp/merge",
+    });
+    orch.store["db"].prepare("UPDATE agents SET cc_session_id = ? WHERE id = ?")
+      .run("cc-merge", "merge");
+    screenState.isAliveResult = true;
+    try { await orch.stopAgent("merge"); } finally { screenState.isAliveResult = false; }
+    createSessionCalls.length = 0;
+
+    await orch.resumeAgent({
+      id: "merge",
+      env: { AGENT_PRIVATE_KEY: "fresh-key", FROM_MANIFEST: "overridden" },
+    });
+
+    const cmd = createSessionCalls[0]!.command;
+    expect(cmd).toContain("FROM_MANIFEST='overridden'");
+    expect(cmd).toContain("AGENT_PRIVATE_KEY='fresh-key'");
+  });
+
+  test("throws when neither tombstone nor cc_session_id is available", async () => {
+    await expect(
+      orch.resumeAgent({ id: "never-existed" }),
+    ).rejects.toThrow(/no cc_session_id supplied and no tombstone/);
   });
 });
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -6,7 +6,7 @@
  */
 
 import { join } from "path";
-import { CrewStore, type Agent, type Tab, type Pane } from "./store.js";
+import { CrewStore, type Agent, type Tab, type Pane, type AgentTombstone } from "./store.js";
 import * as screen from "./screen.js";
 import type { TerminalBackend } from "./terminal.js";
 import { getLaunchCommand } from "./runtimes.js";
@@ -20,6 +20,37 @@ const SCREEN_PREFIX = "wire-";
 function titleCase(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
+
+/** Env keys that must never be persisted to the spawn manifest. */
+const SECRET_ENV_KEYS = new Set([
+  "AGENT_PRIVATE_KEY",
+  "WIRE_PRIVATE_KEY",
+  "CREW_PRIVATE_KEY",
+]);
+
+/** Strip known secret env keys so the manifest can be stored in the DB. */
+function sanitizeEnv(env: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (SECRET_ENV_KEYS.has(k)) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+/** Shape of the persisted spawn manifest (agents.spawn_manifest JSON). */
+export type SpawnManifest = {
+  env: Record<string, string>;       // sanitized — no AGENT_PRIVATE_KEY
+  runtime: string;
+  project_dir: string;
+  extra_flags?: string;
+  prompt?: string;
+  badge?: string;
+  display_name: string;
+  ttl_idle_minutes?: number;
+  /** Only populated for resume-style spawns. */
+  channels?: string[];
+};
 
 /** Escape a string for use in a shell command. */
 function shellEscape(s: string): string {
@@ -121,6 +152,20 @@ export class Orchestrator {
       }
     }, 3000);
 
+    // Persist a sanitized manifest alongside the agent row so agent_resume
+    // can reconstruct the spawn later. AGENT_PRIVATE_KEY is stripped — the
+    // caller re-provisions identity via register_agent on resume.
+    const manifest: SpawnManifest = {
+      env: sanitizeEnv(opts.env),
+      runtime,
+      project_dir: projectDir,
+      extra_flags: opts.extraFlags,
+      prompt: opts.prompt,
+      badge: opts.badge,
+      display_name: displayName,
+      ttl_idle_minutes: opts.ttlIdleMinutes,
+    };
+
     // Record in DB
     return this.store.createAgent({
       id,
@@ -130,6 +175,7 @@ export class Orchestrator {
       screen_pid: session.pid,
       badge: opts.badge,
       ttl_idle_minutes: opts.ttlIdleMinutes,
+      spawn_manifest: JSON.stringify(manifest),
     });
   }
 
@@ -156,30 +202,37 @@ export class Orchestrator {
   async resumeAgent(opts: {
     /** Agent ID to resume. Must not already be alive. */
     id: string;
-    /** Claude Code session ID (the JSONL filename stem). */
-    ccSessionId: string;
-    /** Working directory for the resumed process. */
-    projectDir: string;
-    /** Optional env — mirrors launchAgent semantics. */
+    /**
+     * Claude Code session ID (the JSONL filename stem). Falls back to the
+     * tombstone's cc_session_id if a tombstone exists for `id`.
+     */
+    ccSessionId?: string;
+    /** Working directory. Falls back to the tombstone manifest's project_dir. */
+    projectDir?: string;
+    /**
+     * Env overrides. Merged on top of the tombstone manifest's env (overrides
+     * win). AGENT_PRIVATE_KEY is stripped from the manifest for security, so
+     * callers who want Wire identity should re-provision via register_agent
+     * and pass the new key here.
+     */
     env?: Record<string, string>;
-    /** Dev-channel plugin list. Defaults to ["plugin:wire@agiterra"]. */
+    /**
+     * Dev-channel plugin list. Falls back to tombstone manifest's channels,
+     * then to ["plugin:wire@agiterra"]. Explicit list sidesteps the
+     * --resume / --dangerously-load-development-channels argparser conflict.
+     */
     channels?: string[];
-    /** Runtime name. Default: claude-code. */
+    /** Runtime name. Default: tombstone's runtime or "claude-code". */
     runtime?: string;
-    /** Display name. Defaults to env.AGENT_NAME or opts.id. */
+    /** Display name. Falls back to tombstone manifest's display_name. */
     displayName?: string;
     /** Additional CLI flags appended after --resume. */
     extraFlags?: string;
     /** Optional pane to attach to once the resumed screen is up. */
     attachToPane?: string;
-    /** Optional badge text — forwarded to agent record + pane on attach. */
+    /** Badge text. Falls back to tombstone's badge. */
     badge?: string;
   }): Promise<Agent> {
-    if (opts.runtime && opts.runtime !== "claude-code") {
-      throw new Error(`resumeAgent only supports claude-code today (got '${opts.runtime}')`);
-    }
-    const runtime = opts.runtime ?? "claude-code";
-
     // Refuse to double-resume
     const existing = this.store.getAgent(opts.id);
     if (existing) {
@@ -194,26 +247,65 @@ export class Orchestrator {
       this.store.deleteAgentByScreen(existing.screen_name);
     }
 
-    const env: Record<string, string> = { ...(opts.env ?? {}), AGENT_ID: opts.id };
+    // Pull defaults from the most recent tombstone, if one exists.
+    const tomb = this.store.getLatestTombstone(opts.id);
+    let manifest: SpawnManifest | null = null;
+    if (tomb?.spawn_manifest) {
+      try {
+        manifest = JSON.parse(tomb.spawn_manifest) as SpawnManifest;
+      } catch (e) {
+        console.error(`[crew] resumeAgent: failed to parse tombstone manifest for '${opts.id}':`, e);
+      }
+    }
+
+    const ccSessionId = opts.ccSessionId ?? tomb?.cc_session_id ?? null;
+    if (!ccSessionId) {
+      throw new Error(
+        `resumeAgent: no cc_session_id supplied and no tombstone for '${opts.id}'. ` +
+        `Pass cc_session_id explicitly, or launch the agent once via agent_launch so a manifest is recorded.`,
+      );
+    }
+
+    const projectDir = opts.projectDir ?? manifest?.project_dir;
+    if (!projectDir) {
+      throw new Error(
+        `resumeAgent: no project_dir supplied and no tombstone manifest for '${opts.id}'. ` +
+        `Pass project_dir explicitly.`,
+      );
+    }
+
+    const runtime = opts.runtime ?? tomb?.runtime ?? manifest?.runtime ?? "claude-code";
+    if (runtime !== "claude-code") {
+      throw new Error(`resumeAgent only supports claude-code today (got '${runtime}')`);
+    }
+
+    // Merge env: manifest (sanitized, no private key) < opts.env < { AGENT_ID }
+    const mergedEnv: Record<string, string> = {
+      ...(manifest?.env ?? {}),
+      ...(opts.env ?? {}),
+      AGENT_ID: opts.id,
+    };
     if (opts.env?.AGENT_ID && opts.env.AGENT_ID !== opts.id) {
       throw new Error(`resumeAgent: opts.id ('${opts.id}') does not match env.AGENT_ID ('${opts.env.AGENT_ID}')`);
     }
-    const displayName = opts.displayName ?? env.AGENT_NAME ?? opts.id;
+    const displayName = opts.displayName ?? mergedEnv.AGENT_NAME ?? manifest?.display_name ?? tomb?.display_name ?? opts.id;
+    const badge = opts.badge ?? manifest?.badge ?? tomb?.badge ?? undefined;
+    const extraFlags = opts.extraFlags ?? manifest?.extra_flags;
+    const channels = (opts.channels ?? manifest?.channels ?? ["plugin:wire@agiterra"]).join(",");
     const screenName = `${SCREEN_PREFIX}${opts.id}`;
-    const channels = (opts.channels ?? ["plugin:wire@agiterra"]).join(",");
 
     // Build: claude --dangerously-load-development-channels <channels> \
     //        --permission-mode bypassPermissions --resume <cc_session_id> [extra]
     // Explicit channels list sidesteps the --resume positional-arg conflict.
     let command =
       `claude --dangerously-load-development-channels ${shellEscape(channels)} ` +
-      `--permission-mode bypassPermissions --resume ${shellEscape(opts.ccSessionId)}`;
-    if (opts.extraFlags) command += ` ${opts.extraFlags}`;
+      `--permission-mode bypassPermissions --resume ${shellEscape(ccSessionId)}`;
+    if (extraFlags) command += ` ${extraFlags}`;
 
-    const envExports = `export ${Object.entries(env)
+    const envExports = `export ${Object.entries(mergedEnv)
       .map(([k, v]) => `${k}=${shellEscape(v)}`)
       .join(" ")}`;
-    const fullCommand = `cd ${shellEscape(opts.projectDir)} && ${envExports} && ${command}`;
+    const fullCommand = `cd ${shellEscape(projectDir)} && ${envExports} && ${command}`;
 
     const session = await screen.createSession(screenName, fullCommand);
 
@@ -226,18 +318,32 @@ export class Orchestrator {
       }
     }, 3000);
 
-    // Seed the DB row directly from what the caller told us — no need to
-    // wait for the resumed agent to self-register (and no risk of the
-    // callerSessionId trap biting; we have no callerSessionId here).
+    // Write a fresh manifest for the resumed agent so it can be resumed
+    // again later. Channels flow into the manifest only here (launchAgent
+    // doesn't record them because the runtime command template carries
+    // the default). Env is re-sanitized.
+    const resumedManifest: SpawnManifest = {
+      env: sanitizeEnv(mergedEnv),
+      runtime,
+      project_dir: projectDir,
+      extra_flags: extraFlags,
+      badge,
+      display_name: displayName,
+      ttl_idle_minutes: manifest?.ttl_idle_minutes,
+      channels: opts.channels ?? manifest?.channels,
+    };
+
     const created = this.store.createAgent({
       id: opts.id,
       display_name: displayName,
       runtime,
       screen_name: screenName,
       screen_pid: session.pid,
-      cc_session_id: opts.ccSessionId,
+      cc_session_id: ccSessionId,
       pane: undefined,
-      badge: opts.badge,
+      badge,
+      ttl_idle_minutes: manifest?.ttl_idle_minutes,
+      spawn_manifest: JSON.stringify(resumedManifest),
     });
 
     // If the caller wants the resumed agent visible, attach now. attachAgent
@@ -363,6 +469,8 @@ export class Orchestrator {
     }
 
     await screen.killSession(agent.screen_name);
+    // Leave a tombstone so agent_resume can reconstruct the spawn later.
+    this.store.tombstoneAgent(agent);
     this.store.deleteAgentByScreen(agent.screen_name);
   }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -37,6 +37,26 @@ export type Agent = {
   launched_at: number;
   last_seen: number;
   ttl_idle_minutes: number | null;
+  spawn_manifest: string | null;
+};
+
+/**
+ * Tombstone left behind when an agent is stopped. Lets agent_resume
+ * reconstruct the spawn without the caller re-supplying every arg.
+ *
+ * `env_json` is the manifest's env map with secrets stripped
+ * (AGENT_PRIVATE_KEY in particular) — callers re-provision identity
+ * via register_agent and pass the new key as an override on resume.
+ */
+export type AgentTombstone = {
+  id: string;
+  screen_name: string;
+  display_name: string;
+  runtime: string;
+  cc_session_id: string | null;
+  badge: string | null;
+  spawn_manifest: string | null;
+  stopped_at: number;
 };
 
 export class CrewStore {
@@ -175,6 +195,31 @@ export class CrewStore {
     if (!hasTtl) {
       this.db.exec("ALTER TABLE agents ADD COLUMN ttl_idle_minutes INTEGER");
     }
+
+    // Add spawn_manifest column (v2.3.0 persistent manifest for agent_resume).
+    const hasManifest = this.db.prepare(
+      "SELECT * FROM pragma_table_info('agents') WHERE name='spawn_manifest'"
+    ).get();
+    if (!hasManifest) {
+      this.db.exec("ALTER TABLE agents ADD COLUMN spawn_manifest TEXT");
+    }
+
+    // Tombstone table — one row per stop, keyed by (id, stopped_at) so
+    // multiple resume cycles for the same id each leave a record.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS agent_tombstones (
+        id TEXT NOT NULL,
+        screen_name TEXT NOT NULL,
+        display_name TEXT NOT NULL,
+        runtime TEXT NOT NULL,
+        cc_session_id TEXT,
+        badge TEXT,
+        spawn_manifest TEXT,
+        stopped_at INTEGER NOT NULL,
+        PRIMARY KEY (id, stopped_at)
+      );
+      CREATE INDEX IF NOT EXISTS idx_tombstones_id ON agent_tombstones(id);
+    `);
   }
 
   // --- Tabs ---
@@ -270,16 +315,18 @@ export class CrewStore {
     pane?: string;
     badge?: string;
     ttl_idle_minutes?: number;
+    spawn_manifest?: string;
   }): Agent {
     const now = Date.now();
     this.db.prepare(
-      `INSERT INTO agents (id, display_name, runtime, screen_name, screen_pid, cc_session_id, pane, badge, launched_at, last_seen, ttl_idle_minutes)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO agents (id, display_name, runtime, screen_name, screen_pid, cc_session_id, pane, badge, launched_at, last_seen, ttl_idle_minutes, spawn_manifest)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       agent.id, agent.display_name, agent.runtime, agent.screen_name,
       agent.screen_pid ?? null, agent.cc_session_id ?? null,
       agent.pane ?? null, agent.badge ?? null, now, now,
       agent.ttl_idle_minutes ?? null,
+      agent.spawn_manifest ?? null,
     );
     return {
       id: agent.id,
@@ -295,7 +342,39 @@ export class CrewStore {
       launched_at: now,
       last_seen: now,
       ttl_idle_minutes: agent.ttl_idle_minutes ?? null,
+      spawn_manifest: agent.spawn_manifest ?? null,
     };
+  }
+
+  /** Copy an agent row into the tombstones table. Call before deleteAgent. */
+  tombstoneAgent(agent: Agent): void {
+    this.db.prepare(
+      `INSERT OR REPLACE INTO agent_tombstones
+       (id, screen_name, display_name, runtime, cc_session_id, badge, spawn_manifest, stopped_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      agent.id, agent.screen_name, agent.display_name, agent.runtime,
+      agent.cc_session_id, agent.badge, agent.spawn_manifest, Date.now(),
+    );
+  }
+
+  /** Get the most recent tombstone for an id, or null if none. */
+  getLatestTombstone(id: string): AgentTombstone | null {
+    return this.db.prepare(
+      "SELECT * FROM agent_tombstones WHERE id = ? ORDER BY stopped_at DESC LIMIT 1"
+    ).get(id) as AgentTombstone | null;
+  }
+
+  /** List tombstones (most recent first). Used for debugging / resume UIs. */
+  listTombstones(id?: string, limit = 50): AgentTombstone[] {
+    if (id) {
+      return this.db.prepare(
+        "SELECT * FROM agent_tombstones WHERE id = ? ORDER BY stopped_at DESC LIMIT ?"
+      ).all(id, limit) as AgentTombstone[];
+    }
+    return this.db.prepare(
+      "SELECT * FROM agent_tombstones ORDER BY stopped_at DESC LIMIT ?"
+    ).all(limit) as AgentTombstone[];
   }
 
   setAgentTtl(id: string, minutes: number | null): void {


### PR DESCRIPTION
Closes #40. `agent_resume({id})` works with just the id now — the rest is pulled from the tombstone written at agent_stop time.

Tests: 79 pass / 0 fail (5 new covering manifest persistence, tombstone write-on-stop, single-arg resume, env-override merging, and the no-tombstone error path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)