### PR TITLE
fix: agent_badge skips render on multi-claimed pane; v2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -600,10 +600,11 @@ export async function startServer(): Promise<void> {
             ccSessionId: (a.cc_session_id as string | undefined) ?? ccSessionId ?? undefined,
           });
           break;
-        case "agent_badge":
-          await orchestrator.setAgentBadge(a.id as string, a.text as string);
-          result = { badge_set: a.id, text: a.text };
+        case "agent_badge": {
+          const outcome = await orchestrator.setAgentBadge(a.id as string, a.text as string);
+          result = { badge_set: a.id, text: a.text, ...outcome };
           break;
+        }
         case "agent_interrupt":
           result = await orchestrator.interruptAgent(a.id as string, !!a.background, a.cc_session_id as string | undefined);
           break;

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -265,6 +265,43 @@ describe("spawn manifest + tombstones", () => {
   });
 });
 
+describe("setAgentBadge ambiguous-pane safeguard", () => {
+  test("skips render when multiple agents claim the target's pane", async () => {
+    // Construct the bad state: two agents both claim pane 'shared'.
+    await orch.launchAgent({ env: { AGENT_ID: "a" } });
+    await orch.launchAgent({ env: { AGENT_ID: "b" } });
+    orch.store["db"].prepare("UPDATE agents SET pane = 'shared' WHERE id IN ('a','b')").run();
+
+    const outcome = await orch.setAgentBadge("a", "should-not-render");
+
+    expect(outcome.rendered).toBe(false);
+    expect(outcome.reason).toMatch(/claimed by 2 agents/);
+    // DB badge still written — only the pane render is skipped.
+    expect(orch.store.getAgent("a")?.badge).toBe("should-not-render");
+  });
+
+  test("skips render when the target's screen is detached", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "lonely" } });
+    orch.store["db"].prepare("UPDATE agents SET pane = 'rome' WHERE id = 'lonely'").run();
+    // Fake a pane row so the iterm_id lookup succeeds.
+    orch.store["db"].prepare(
+      "INSERT INTO tabs (name, created_at) VALUES ('t', 0)"
+    ).run();
+    orch.store["db"].prepare(
+      "INSERT INTO panes (name, tab, position, iterm_id, created_at) VALUES ('rome','t','below','iterm-rome',0)"
+    ).run();
+
+    screenState.isAttachedResult = false; // detached
+    try {
+      const outcome = await orch.setAgentBadge("lonely", "x");
+      expect(outcome.rendered).toBe(false);
+      expect(outcome.reason).toMatch(/detached/);
+    } finally {
+      screenState.isAttachedResult = false;
+    }
+  });
+});
+
 describe("resumeAgent", () => {
   test("builds a claude --resume command with explicit channels list", async () => {
     await orch.resumeAgent({

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -573,17 +573,65 @@ export class Orchestrator {
   /**
    * Update an agent's badge text. Persists in the DB and applies to the
    * pane immediately if the agent is currently attached.
+   *
+   * Returns a summary of what happened: the DB badge is always written;
+   * the pane render is skipped when the pane's occupancy is ambiguous
+   * (more than one agent row claims it). Ambiguous panes happen when an
+   * operator reattaches a screen via raw `screen -x` or iTerm controls
+   * instead of `agent_attach`, leaving the DB lying about which pane
+   * shows which agent. Rendering the badge in that state would push the
+   * escape sequence to whichever iTerm session the pane is wired to,
+   * clobbering whatever agent is ACTUALLY displayed there — classically
+   * the caller's own badge.
    */
-  async setAgentBadge(agentId: string, badge: string): Promise<void> {
+  async setAgentBadge(agentId: string, badge: string): Promise<{
+    rendered: boolean;
+    pane: string | null;
+    reason?: string;
+  }> {
     const agent = this.store.getAgent(agentId);
     if (!agent) throw new Error(`agent '${agentId}' not found`);
     this.store.setAgentBadge(agentId, badge);
-    if (agent.pane) {
-      const pane = this.store.getPane(agent.pane);
-      if (pane?.iterm_id) {
-        await this.terminal.setBadge(pane.iterm_id, badge);
-      }
+
+    if (!agent.pane) {
+      return { rendered: false, pane: null, reason: "agent is headless (no pane)" };
     }
+
+    // Invariant: each pane hosts at most one agent. Check BEFORE iterm_id
+    // resolution — a drifted DB is a more informative signal than "no iterm
+    // session." If multiple rows claim this pane we cannot safely render:
+    // the iterm_id may be wired to a different agent, and rendering would
+    // clobber whoever is actually displayed (classically the caller's own
+    // badge, when an operator calls agent_badge for another agent that
+    // nominally shares the caller's pane).
+    const claimants = this.store.listAgents().filter((a) => a.pane === agent.pane);
+    if (claimants.length > 1) {
+      const reason =
+        `pane '${agent.pane}' is claimed by ${claimants.length} agents (${claimants.map((c) => c.id).join(", ")}). ` +
+        `DB is stale — probably an operator reattached a screen outside of agent_attach. ` +
+        `Resolve by calling agent_attach / agent_detach on the affected agents, or run reconcile.`;
+      console.error(`[crew] setAgentBadge skipped render: ${reason}`);
+      return { rendered: false, pane: agent.pane, reason };
+    }
+
+    const pane = this.store.getPane(agent.pane);
+    if (!pane?.iterm_id) {
+      return { rendered: false, pane: agent.pane, reason: "pane has no iterm session" };
+    }
+
+    // Defence in depth: if the target's screen session isn't attached to any
+    // terminal right now, the DB pane is stale (headless agents can't render).
+    const attached = await screen.isAttached(agent.screen_name);
+    if (!attached) {
+      return {
+        rendered: false,
+        pane: agent.pane,
+        reason: `target screen '${agent.screen_name}' is detached — rendering would go to a stale iterm session`,
+      };
+    }
+
+    await this.terminal.setBadge(pane.iterm_id, badge);
+    return { rendered: true, pane: agent.pane };
   }
 
   /**


### PR DESCRIPTION
Bug reported by Brioche (seq 3361) — agent_badge for another agent was clobbering the caller's own badge when DB drift made multiple agents claim the same pane.

Tests: 81/0. Two new cases cover the multi-claimant and detached-screen paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)