### PR TITLE
feat: machine-aware crew (primitive 1 of cross-machine handoff); v2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -563,6 +563,63 @@ export async function startServer(): Promise<void> {
       description: "Sync DB state with running screen sessions.",
       inputSchema: { type: "object" as const, properties: {} },
     },
+    {
+      name: "machine_register",
+      description:
+        "Register a machine in the local crew DB so cross-machine tools " +
+        "(crew-fleet, fleet_move) can reach it. Probes SSH with " +
+        "BatchMode=yes + ConnectTimeout=5 and reads the remote crew " +
+        "plugin version. Each crew DB is local-truth for 'machines I " +
+        "know how to reach' — no central registry. Pass `reciprocal: " +
+        "true` to also register the local machine on the remote side.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          name: { type: "string", description: "User-friendly alias (e.g. 'home-mini')." },
+          ssh_host: { type: "string", description: "SSH destination (e.g. 'tim@mac-mini.local')." },
+          ssh_port: { type: "number", description: "Optional SSH port. Default: 22." },
+          notes: { type: "string", description: "Free-form notes." },
+          skip_probe: { type: "boolean", description: "Skip the SSH reachability check at register time (default false)." },
+          reciprocal: { type: "boolean", description: "If true, SSH to the destination and register the local machine there too. (Best-effort; failure is non-fatal.)" },
+        },
+        required: ["name", "ssh_host"],
+      },
+    },
+    {
+      name: "machine_list",
+      description:
+        "List all machines registered in the local crew DB. The local " +
+        "machine is auto-registered on first boot and appears as a row " +
+        "with ssh_host='localhost'.",
+      inputSchema: { type: "object" as const, properties: {} },
+    },
+    {
+      name: "machine_remove",
+      description:
+        "Remove a registered machine. Refuses to delete the local " +
+        "machine — its row is required for agents.machine_name joins.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          name: { type: "string", description: "Machine name to remove." },
+        },
+        required: ["name"],
+      },
+    },
+    {
+      name: "machine_probe",
+      description:
+        "Re-probe a registered machine for reachability. Updates " +
+        "last_seen + crew_version on success; returns the probe result " +
+        "either way.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          name: { type: "string", description: "Machine name to probe." },
+        },
+        required: ["name"],
+      },
+    },
   ];
 
   mcp.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
@@ -760,6 +817,36 @@ export async function startServer(): Promise<void> {
         }
         case "reconcile":
           result = { report: await orchestrator.reconcile() };
+          break;
+        case "machine_register": {
+          const m = await orchestrator.registerMachine({
+            name: a.name as string,
+            sshHost: a.ssh_host as string,
+            sshPort: a.ssh_port as number | undefined,
+            notes: a.notes as string | undefined,
+            skipProbe: Boolean(a.skip_probe),
+          });
+          // Best-effort reciprocal: SSH to the destination and run
+          // `claude -p` / equivalent to invoke its own machine_register
+          // pointing back at us. For now we only note the intent; the
+          // reciprocal wiring lands with crew-fleet (#50) where we have
+          // a clean remote-MCP-invoke primitive.
+          if (a.reciprocal) {
+            result = { ...m, reciprocal_note: "reciprocal registration deferred to crew-fleet; register on the remote side manually for now" };
+          } else {
+            result = m;
+          }
+          break;
+        }
+        case "machine_list":
+          result = orchestrator.listMachines();
+          break;
+        case "machine_remove":
+          orchestrator.removeMachine(a.name as string);
+          result = { removed: a.name };
+          break;
+        case "machine_probe":
+          result = await orchestrator.probeMachine(a.name as string);
           break;
         default:
           throw new Error(`unknown tool: ${name}`);

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -213,6 +213,60 @@ describe("idle TTL + reaper", () => {
   });
 });
 
+describe("machine-aware crew (v2.4.0)", () => {
+  test("first-boot auto-registers the local machine", () => {
+    const machines = orch.store.listMachines();
+    expect(machines).toHaveLength(1);
+    expect(machines[0].name).toBe(orch.store.localMachineName());
+    expect(machines[0].ssh_host).toBe("localhost");
+  });
+
+  test("launchAgent stamps machine_name on the agent row", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "mx" } });
+    const agent = orch.store.getAgent("mx");
+    expect(agent?.machine_name).toBe(orch.store.localMachineName());
+  });
+
+  test("createMachine + listMachines round-trip", () => {
+    orch.store.createMachine({
+      name: "home-mini",
+      hostname: "home-mini",
+      ssh_host: "tim@home-mini.local",
+    });
+    const names = orch.store.listMachines().map((m) => m.name).sort();
+    expect(names).toContain("home-mini");
+    expect(names).toContain(orch.store.localMachineName());
+  });
+
+  test("deleteMachine refuses to remove the local machine", () => {
+    expect(() => orch.store.deleteMachine(orch.store.localMachineName())).toThrow(
+      /refusing to remove local machine/,
+    );
+  });
+
+  test("deleteMachine removes non-local rows", () => {
+    orch.store.createMachine({
+      name: "other",
+      hostname: "other",
+      ssh_host: "tim@other.local",
+    });
+    orch.store.deleteMachine("other");
+    expect(orch.store.getMachine("other")).toBeNull();
+  });
+
+  test("updateMachineProbe refreshes last_seen and crew_version", () => {
+    orch.store.createMachine({
+      name: "probe-target",
+      hostname: "probe-target",
+      ssh_host: "tim@probe-target.local",
+    });
+    orch.store.updateMachineProbe("probe-target", { last_seen: 12345, crew_version: "2.4.0" });
+    const m = orch.store.getMachine("probe-target");
+    expect(m?.last_seen).toBe(12345);
+    expect(m?.crew_version).toBe("2.4.0");
+  });
+});
+
 describe("spawn manifest + tombstones", () => {
   test("launchAgent persists a manifest stripped of AGENT_PRIVATE_KEY", async () => {
     await orch.launchAgent({

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -6,7 +6,7 @@
  */
 
 import { join } from "path";
-import { CrewStore, type Agent, type Tab, type Pane, type AgentTombstone } from "./store.js";
+import { CrewStore, type Agent, type Tab, type Pane, type AgentTombstone, type Machine } from "./store.js";
 import * as screen from "./screen.js";
 import type { TerminalBackend } from "./terminal.js";
 import { getLaunchCommand } from "./runtimes.js";
@@ -1181,6 +1181,114 @@ export class Orchestrator {
     }
 
     return { updated, errors };
+  }
+
+  // --- Machines (cross-machine orchestration registry) ---
+
+  /**
+   * Register a machine in the local crew DB so crew-fleet can fan-out
+   * queries + handoffs to it. Probes SSH reachability; refuses to
+   * register unreachable hosts unless `skipProbe` is set.
+   */
+  async registerMachine(opts: {
+    name: string;
+    sshHost: string;
+    sshPort?: number;
+    notes?: string;
+    skipProbe?: boolean;
+  }): Promise<Machine> {
+    const existing = this.store.getMachine(opts.name);
+    if (existing) {
+      throw new Error(
+        `registerMachine: '${opts.name}' is already registered (ssh_host='${existing.ssh_host}'). ` +
+        `Call machine_remove first if you want to re-register.`,
+      );
+    }
+    let probedHostname = opts.name;
+    let crewVersion: string | undefined;
+    if (!opts.skipProbe) {
+      const probe = await this.probeMachineSsh(opts.sshHost, opts.sshPort);
+      if (!probe.reachable) {
+        throw new Error(
+          `registerMachine: SSH probe to '${opts.sshHost}' failed: ${probe.error ?? "unreachable"}. ` +
+          `Pass skipProbe: true to register anyway.`,
+        );
+      }
+      probedHostname = probe.hostname ?? opts.name;
+      crewVersion = probe.crewVersion;
+    }
+    const row = this.store.createMachine({
+      name: opts.name,
+      hostname: probedHostname,
+      ssh_host: opts.sshHost,
+      ssh_port: opts.sshPort,
+      notes: opts.notes,
+    });
+    if (crewVersion) {
+      this.store.updateMachineProbe(opts.name, { last_seen: Date.now(), crew_version: crewVersion });
+    }
+    return this.store.getMachine(opts.name) ?? row;
+  }
+
+  listMachines(): Machine[] {
+    return this.store.listMachines();
+  }
+
+  removeMachine(name: string): void {
+    this.store.deleteMachine(name);
+  }
+
+  /**
+   * Re-probe a registered machine. Updates `last_seen` and `crew_version`
+   * in the DB. Returns the probe result.
+   */
+  async probeMachine(name: string): Promise<{ reachable: boolean; hostname?: string; crewVersion?: string; error?: string }> {
+    const m = this.store.getMachine(name);
+    if (!m) throw new Error(`probeMachine: '${name}' not registered`);
+    const probe = await this.probeMachineSsh(m.ssh_host, m.ssh_port ?? undefined);
+    if (probe.reachable) {
+      this.store.updateMachineProbe(name, {
+        last_seen: Date.now(),
+        crew_version: probe.crewVersion,
+      });
+    }
+    return probe;
+  }
+
+  /**
+   * Low-level SSH probe: `ssh <host> 'hostname && bun ... --version'`.
+   * Returns reachable + remote hostname + crew version (if detectable).
+   * All failures reduce to `{ reachable: false, error }` so callers get a
+   * uniform shape. Timeout is 5 seconds.
+   */
+  private async probeMachineSsh(
+    sshHost: string,
+    sshPort?: number,
+  ): Promise<{ reachable: boolean; hostname?: string; crewVersion?: string; error?: string }> {
+    try {
+      const portArg = sshPort ? ["-p", String(sshPort)] : [];
+      const proc = Bun.spawn(
+        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5", ...portArg, sshHost, "hostname && (cat ~/.claude/plugins/cache/agiterra/crew/*/package.json 2>/dev/null | grep '\"version\"' | head -1 || true)"],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const exitCode = await proc.exited;
+      if (exitCode !== 0) {
+        const err = await new Response(proc.stderr).text();
+        return { reachable: false, error: err.trim() || `exit ${exitCode}` };
+      }
+      const out = (await new Response(proc.stdout).text()).trim().split("\n");
+      const remoteHost = out[0]?.toLowerCase() ?? undefined;
+      const versionLine = out.find((l) => l.includes('"version"'));
+      const versionMatch = versionLine?.match(/"version":\s*"([^"]+)"/);
+      return {
+        reachable: true,
+        hostname: remoteHost,
+        crewVersion: versionMatch?.[1],
+      };
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { reachable: false, error: msg };
+    }
   }
 
   // --- Reconciler ---

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,6 +6,7 @@
  */
 
 import { Database } from "bun:sqlite";
+import { hostname } from "os";
 
 export type Tab = {
   name: string;
@@ -38,6 +39,33 @@ export type Agent = {
   last_seen: number;
   ttl_idle_minutes: number | null;
   spawn_manifest: string | null;
+  /**
+   * Which machine this agent runs on. Populated from `hostname()` at
+   * insert time. Enables cross-machine orchestration (see crew-fleet
+   * plugin) — fleet-level queries union agent rows across every
+   * machine's local crew DB, annotated by this column.
+   */
+  machine_name: string;
+};
+
+/**
+ * A machine the orchestrator can SSH into. Used by crew-fleet for
+ * cross-machine queries and by fleet_move for handoffs.
+ *
+ * Each crew DB is local-truth for "machines I know how to reach." There
+ * is no central registry — register a machine on both sides if you want
+ * bidirectional awareness (machine_register supports `reciprocal: true`
+ * as a convenience).
+ */
+export type Machine = {
+  name: string;              // user-friendly alias ("home-mini")
+  hostname: string;          // OS hostname, for dedupe + self-detect
+  ssh_host: string;          // 'tim@mac-mini.local' or similar
+  ssh_port: number | null;   // null = default 22
+  added_at: number;
+  last_seen: number | null;
+  crew_version: string | null;
+  notes: string | null;
 };
 
 /**
@@ -220,6 +248,43 @@ export class CrewStore {
       );
       CREATE INDEX IF NOT EXISTS idx_tombstones_id ON agent_tombstones(id);
     `);
+
+    // Add machine_name column to agents (v2.4.0). Default is the local
+    // hostname so every pre-existing row gets a sensible value. The column
+    // is NOT NULL in principle; we default in application code rather than
+    // DB-side DEFAULT because sqlite ALTER TABLE DEFAULT can't reference
+    // functions at migration time.
+    const hasMachineName = this.db.prepare(
+      "SELECT * FROM pragma_table_info('agents') WHERE name='machine_name'"
+    ).get();
+    if (!hasMachineName) {
+      const localName = hostname().toLowerCase();
+      this.db.exec(`ALTER TABLE agents ADD COLUMN machine_name TEXT NOT NULL DEFAULT '${localName.replace(/'/g, "''")}'`);
+    }
+
+    // Machines table (v2.4.0) — cross-machine orchestration registry.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS machines (
+        name TEXT PRIMARY KEY,
+        hostname TEXT NOT NULL,
+        ssh_host TEXT NOT NULL,
+        ssh_port INTEGER,
+        added_at INTEGER NOT NULL,
+        last_seen INTEGER,
+        crew_version TEXT,
+        notes TEXT
+      );
+    `);
+
+    // First-boot: ensure the local machine is registered so JOINs on
+    // agents.machine_name always resolve for local rows. Idempotent.
+    const localHost = hostname().toLowerCase();
+    const localRow = this.db.prepare("SELECT 1 FROM machines WHERE name = ?").get(localHost);
+    if (!localRow) {
+      this.db.prepare(
+        "INSERT INTO machines (name, hostname, ssh_host, ssh_port, added_at, last_seen, crew_version, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+      ).run(localHost, localHost, "localhost", null, Date.now(), Date.now(), null, "auto-registered on first boot");
+    }
   }
 
   // --- Tabs ---
@@ -318,15 +383,17 @@ export class CrewStore {
     spawn_manifest?: string;
   }): Agent {
     const now = Date.now();
+    const machineName = hostname().toLowerCase();
     this.db.prepare(
-      `INSERT INTO agents (id, display_name, runtime, screen_name, screen_pid, cc_session_id, pane, badge, launched_at, last_seen, ttl_idle_minutes, spawn_manifest)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO agents (id, display_name, runtime, screen_name, screen_pid, cc_session_id, pane, badge, launched_at, last_seen, ttl_idle_minutes, spawn_manifest, machine_name)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       agent.id, agent.display_name, agent.runtime, agent.screen_name,
       agent.screen_pid ?? null, agent.cc_session_id ?? null,
       agent.pane ?? null, agent.badge ?? null, now, now,
       agent.ttl_idle_minutes ?? null,
       agent.spawn_manifest ?? null,
+      machineName,
     );
     return {
       id: agent.id,
@@ -343,6 +410,7 @@ export class CrewStore {
       last_seen: now,
       ttl_idle_minutes: agent.ttl_idle_minutes ?? null,
       spawn_manifest: agent.spawn_manifest ?? null,
+      machine_name: machineName,
     };
   }
 
@@ -451,5 +519,69 @@ export class CrewStore {
     this.db.prepare(
       "UPDATE agents SET cc_session_id = ?, last_seen = ? WHERE screen_name = ?"
     ).run(ccSessionId, Date.now(), screenName);
+  }
+
+  // --- Machines ---
+
+  /** Return the local machine's registry name (lowercase OS hostname). */
+  localMachineName(): string {
+    return hostname().toLowerCase();
+  }
+
+  createMachine(opts: {
+    name: string;
+    hostname: string;
+    ssh_host: string;
+    ssh_port?: number;
+    notes?: string;
+  }): Machine {
+    const now = Date.now();
+    this.db.prepare(
+      `INSERT INTO machines (name, hostname, ssh_host, ssh_port, added_at, last_seen, crew_version, notes)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      opts.name, opts.hostname, opts.ssh_host, opts.ssh_port ?? null,
+      now, null, null, opts.notes ?? null,
+    );
+    return {
+      name: opts.name,
+      hostname: opts.hostname,
+      ssh_host: opts.ssh_host,
+      ssh_port: opts.ssh_port ?? null,
+      added_at: now,
+      last_seen: null,
+      crew_version: null,
+      notes: opts.notes ?? null,
+    };
+  }
+
+  getMachine(name: string): Machine | null {
+    return this.db.prepare("SELECT * FROM machines WHERE name = ?").get(name) as Machine | null;
+  }
+
+  listMachines(): Machine[] {
+    return this.db.prepare("SELECT * FROM machines ORDER BY name").all() as Machine[];
+  }
+
+  /**
+   * Remove a machine by name. Refuses to delete the local machine —
+   * every crew DB needs to retain self-knowledge so agents.machine_name
+   * JOINs against machines still resolve for locally-spawned rows.
+   */
+  deleteMachine(name: string): void {
+    if (name === this.localMachineName()) {
+      throw new Error(
+        `deleteMachine: refusing to remove local machine '${name}'. ` +
+        `The local machine is auto-registered on every boot and is required ` +
+        `for agents.machine_name joins to resolve.`,
+      );
+    }
+    this.db.prepare("DELETE FROM machines WHERE name = ?").run(name);
+  }
+
+  updateMachineProbe(name: string, opts: { last_seen: number; crew_version?: string }): void {
+    this.db.prepare(
+      "UPDATE machines SET last_seen = ?, crew_version = COALESCE(?, crew_version) WHERE name = ?"
+    ).run(opts.last_seen, opts.crew_version ?? null, name);
   }
 }


### PR DESCRIPTION
Closes #49. Adds machines table, machine_name column, machine_* MCP tools. Blocks #50 and #51.

Tests: 88 pass (6 new).