### PR TITLE
fix: reconciler skips peer-machine agents; v2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/reconciler.test.ts
+++ b/src/reconciler.test.ts
@@ -60,6 +60,38 @@ function makeTerminal(aliveSessionIds: string[]): TerminalBackend & { calls: Ter
   return t;
 }
 
+describe("reconcile cross-machine safety", () => {
+  test("skips agents on peer machines (does NOT cascade-delete remote rows)", async () => {
+    // Local row: screen looks dead, reconciler prunes it.
+    store.createAgent({
+      id: "local-dead",
+      display_name: "LocalDead",
+      runtime: "claude-code",
+      screen_name: "wire-local-dead",
+    });
+    // Remote row: pretend the agent lives on home-mini. createAgent stamps
+    // the local hostname, so we UPDATE to simulate a fleet_list insertion.
+    store.createMachine({ name: "home-mini", hostname: "home-mini", ssh_host: "tim@home-mini" });
+    store.createAgent({
+      id: "remote-alive",
+      display_name: "RemoteAlive",
+      runtime: "claude-code",
+      screen_name: "wire-remote-alive",
+    });
+    store["db"].prepare("UPDATE agents SET machine_name = ? WHERE id = ?").run("home-mini", "remote-alive");
+
+    const result = await reconcile(store);
+
+    // Local dead agent got pruned.
+    expect(result.dead).toContain("local-dead");
+    expect(store.getAgent("local-dead")).toBeNull();
+    // Remote agent is untouched — NOT in alive (we don't claim it is) and NOT in dead.
+    expect(result.alive).not.toContain("remote-alive");
+    expect(result.dead).not.toContain("remote-alive");
+    expect(store.getAgent("remote-alive")).not.toBeNull();
+  });
+});
+
 describe("reconcile theme healing", () => {
   test("assigns theme to untheme tab", async () => {
     store.createTab("brioche");

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -45,12 +45,21 @@ export async function reconcile(
   const agents = store.listAgents();
   const sessions = await listSessions();
   const sessionByName = new Map(sessions.map((s) => [s.name, s]));
+  const localMachine = store.localMachineName();
 
   const alive: string[] = [];
   const dead: string[] = [];
   const knownScreenNames = new Set<string>();
 
   for (const agent of agents) {
+    // Cross-machine safety: the local reconciler is NOT authoritative for
+    // agents on peer machines. Their screen sessions live on the remote
+    // host; `screen -ls` here will always return nothing for them. Without
+    // this skip, the first time a peer is registered and fleet_list
+    // populates the DB with remote rows, the next boot would cascade-
+    // delete every remote agent — classic latent fatal bug.
+    if (agent.machine_name !== localMachine) continue;
+
     knownScreenNames.add(agent.screen_name);
     const session = sessionByName.get(agent.screen_name);
     if (session) {


### PR DESCRIPTION
Latent fatal bug — closes #56.

Tests: 97 pass / 0 fail (1 new).