### PR TITLE
feat: reciprocal machine registration + crew machine-register CLI; v2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,12 +25,15 @@ import pkg from "../package.json" with { type: "json" };
 const USAGE = `Usage: crew <command> [args]
 
 Commands:
-  version                           Print crew-tools version.
-  launch  --json <path|->           Launch a fresh agent. JSON opts fed to Orchestrator.launchAgent().
-                                    Use '-' to read from stdin (preferred for secrets like AGENT_PRIVATE_KEY).
-  resume  --json <path|->           Resume a stopped agent.
-  stop    <id> [--cc-session-id ID] Stop an agent. Matches crew's agent_stop MCP tool.
-  agent-send <id> <text>            Send keystrokes to an agent's screen.
+  version                                  Print crew-tools version.
+  launch  --json <path|->                  Launch a fresh agent. JSON opts fed to Orchestrator.launchAgent().
+                                           Use '-' to read from stdin (preferred for secrets like AGENT_PRIVATE_KEY).
+  resume  --json <path|->                  Resume a stopped agent.
+  stop    <id> [--cc-session-id ID]        Stop an agent. Matches crew's agent_stop MCP tool.
+  agent-send <id> <text>                   Send keystrokes to an agent's screen.
+  machine-register --json <path|->         Register a peer machine in this DB. JSON: {name, ssh_host, ssh_port?, notes?, skip_probe?}.
+                                           Used by reciprocal pairing — laptop SSHes mini and runs this to add itself.
+  hostname                                 Print the local hostname (for reciprocal-pairing fallback).
 
 Exit codes: 0 success, 1 usage, 2 orchestrator error.
 `;
@@ -138,6 +141,43 @@ export async function runCli(argv: string[]): Promise<CliResult> {
       } catch (e) {
         return { exit: 2, stderr: `agent-send failed: ${(e as Error).message}\n` };
       }
+    }
+
+    case "machine-register": {
+      const flags = parseFlags(rest);
+      if (!flags.json) {
+        return { exit: 1, stderr: "machine-register requires --json <path-or-'-'>\n" };
+      }
+      let opts: Record<string, unknown>;
+      try {
+        opts = await readJsonArg(flags.json) as Record<string, unknown>;
+      } catch (e) {
+        return { exit: 1, stderr: `invalid JSON: ${(e as Error).message}\n` };
+      }
+      if (!opts.name || typeof opts.name !== "string") {
+        return { exit: 1, stderr: "machine-register JSON must include 'name'\n" };
+      }
+      if (!opts.ssh_host || typeof opts.ssh_host !== "string") {
+        return { exit: 1, stderr: "machine-register JSON must include 'ssh_host'\n" };
+      }
+      try {
+        const orch = new Orchestrator(await createBackend());
+        const m = await orch.registerMachine({
+          name: opts.name,
+          sshHost: opts.ssh_host,
+          sshPort: typeof opts.ssh_port === "number" ? opts.ssh_port : undefined,
+          notes: typeof opts.notes === "string" ? opts.notes : undefined,
+          skipProbe: Boolean(opts.skip_probe),
+        });
+        return { exit: 0, stdout: `${JSON.stringify(m)}\n` };
+      } catch (e) {
+        return { exit: 2, stderr: `machine-register failed: ${(e as Error).message}\n` };
+      }
+    }
+
+    case "hostname": {
+      const { hostname } = await import("os");
+      return { exit: 0, stdout: `${hostname().toLowerCase()}\n` };
     }
 
     default:

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -580,7 +580,8 @@ export async function startServer(): Promise<void> {
           ssh_port: { type: "number", description: "Optional SSH port. Default: 22." },
           notes: { type: "string", description: "Free-form notes." },
           skip_probe: { type: "boolean", description: "Skip the SSH reachability check at register time (default false)." },
-          reciprocal: { type: "boolean", description: "If true, SSH to the destination and register the local machine there too. (Best-effort; failure is non-fatal.)" },
+          reciprocal: { type: "boolean", description: "If true, after registering the destination, SSH to it and register the LOCAL machine in its DB. Best-effort — SSH failure during reciprocal step does not undo the local row." },
+          local_address: { type: "string", description: "Override the SSH-reachable address of the local machine for the reciprocal call. Defaults to '${USER}@${hostname}.local'." },
         },
         required: ["name", "ssh_host"],
       },
@@ -819,23 +820,15 @@ export async function startServer(): Promise<void> {
           result = { report: await orchestrator.reconcile() };
           break;
         case "machine_register": {
-          const m = await orchestrator.registerMachine({
+          result = await orchestrator.registerMachine({
             name: a.name as string,
             sshHost: a.ssh_host as string,
             sshPort: a.ssh_port as number | undefined,
             notes: a.notes as string | undefined,
             skipProbe: Boolean(a.skip_probe),
+            reciprocal: Boolean(a.reciprocal),
+            localAddress: a.local_address as string | undefined,
           });
-          // Best-effort reciprocal: SSH to the destination and run
-          // `claude -p` / equivalent to invoke its own machine_register
-          // pointing back at us. For now we only note the intent; the
-          // reciprocal wiring lands with crew-fleet (#50) where we have
-          // a clean remote-MCP-invoke primitive.
-          if (a.reciprocal) {
-            result = { ...m, reciprocal_note: "reciprocal registration deferred to crew-fleet; register on the remote side manually for now" };
-          } else {
-            result = m;
-          }
           break;
         }
         case "machine_list":

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1196,7 +1196,20 @@ export class Orchestrator {
     sshPort?: number;
     notes?: string;
     skipProbe?: boolean;
-  }): Promise<Machine> {
+    /**
+     * If true, after registering the destination locally, SSH to it and
+     * register the LOCAL machine in its DB too. Best-effort — SSH failure
+     * during reciprocal step is logged but does not undo the local
+     * registration.
+     *
+     * The local machine's reachable address from the destination's POV
+     * is `${USER}@${hostname}.local` by default; override via
+     * `localAddress`.
+     */
+    reciprocal?: boolean;
+    /** Override the local machine's reachable SSH address for the reciprocal call. */
+    localAddress?: string;
+  }): Promise<Machine & { reciprocal?: { ok: boolean; remote_record?: unknown; error?: string } }> {
     const existing = this.store.getMachine(opts.name);
     if (existing) {
       throw new Error(
@@ -1227,7 +1240,57 @@ export class Orchestrator {
     if (crewVersion) {
       this.store.updateMachineProbe(opts.name, { last_seen: Date.now(), crew_version: crewVersion });
     }
-    return this.store.getMachine(opts.name) ?? row;
+    const finalRow = this.store.getMachine(opts.name) ?? row;
+
+    // Reciprocal step: SSH the destination and run `crew machine-register`
+    // with our identity, so the destination's crew DB knows about us.
+    // Best-effort — failure here is logged but doesn't undo the local row.
+    if (opts.reciprocal) {
+      const localAddress = opts.localAddress ?? `${process.env.USER ?? "tim"}@${this.store.localMachineName()}.local`;
+      const reciprocal = await this.reciprocalRegister(
+        opts.sshHost,
+        opts.sshPort,
+        { name: this.store.localMachineName(), ssh_host: localAddress },
+      );
+      return { ...finalRow, reciprocal };
+    }
+
+    return finalRow;
+  }
+
+  /**
+   * SSH the destination and run `crew machine-register --json -` with
+   * our identity as the body. Used by reciprocal pairing. Returns a
+   * structured outcome — never throws.
+   */
+  private async reciprocalRegister(
+    sshHost: string,
+    sshPort: number | undefined,
+    selfRow: { name: string; ssh_host: string; ssh_port?: number; notes?: string },
+  ): Promise<{ ok: boolean; remote_record?: unknown; error?: string }> {
+    try {
+      const portArg = sshPort ? ["-p", String(sshPort)] : [];
+      // Send the JSON via stdin so it doesn't show in the SSH audit log.
+      const proc = Bun.spawn(
+        ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5", ...portArg, sshHost, "crew machine-register --json -"],
+        { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
+      );
+      const stdin = (proc as unknown as { stdin: { write: (s: string) => void; end: () => void } }).stdin;
+      stdin.write(JSON.stringify(selfRow));
+      stdin.end();
+      const exitCode = await proc.exited;
+      const stdout = (await new Response(proc.stdout).text()).trim();
+      const stderr = (await new Response(proc.stderr).text()).trim();
+      if (exitCode !== 0) {
+        return { ok: false, error: stderr || `exit ${exitCode}` };
+      }
+      let remote_record: unknown = stdout;
+      try { remote_record = JSON.parse(stdout); } catch { /* keep as raw */ }
+      return { ok: true, remote_record };
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { ok: false, error: msg };
+    }
   }
 
   listMachines(): Machine[] {


### PR DESCRIPTION
Closes #58. Bidirectional pairing in one call.