### PR TITLE
Drop runtimes.json cache; fix codex spawn launcher bypass; v2.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -33,14 +33,19 @@ const DEFAULTS: Record<string, RuntimeConfig> = {
 
 const CONFIG_PATH = join(process.env.HOME ?? "/tmp", ".wire", "runtimes.json");
 
-let _cache: Record<string, RuntimeConfig> | null = null;
-
 /**
  * Load runtime registry: defaults merged with user config.
+ *
+ * Re-reads ~/.wire/runtimes.json on every call. The file is tiny and
+ * agent_launch is rare; the previous module-level cache silently ignored
+ * runtimes.json edits made after process startup. That bit four codex
+ * spawns across 2026-04-27 / 04-28 / 04-29 (Beignet, Madeleine, Cruller,
+ * Strudel) — each agent ran the default `codex` command bypassing the
+ * `~/.wire/codex-launch.sh` override, even after CC restarts. Read-fresh
+ * removes the bug class entirely; no race between restart, MCP child
+ * orphaning, and edits to runtimes.json.
  */
 export function loadRuntimes(): Record<string, RuntimeConfig> {
-  if (_cache) return _cache;
-
   const runtimes = { ...DEFAULTS };
 
   if (existsSync(CONFIG_PATH)) {
@@ -58,7 +63,6 @@ export function loadRuntimes(): Record<string, RuntimeConfig> {
     }
   }
 
-  _cache = runtimes;
   return runtimes;
 }
 


### PR DESCRIPTION
## Summary
- Module-level cache in `loadRuntimes()` silently ignored `~/.wire/runtimes.json` edits made after host MCP startup
- Bit four codex spawns (Beignet 04-27, Madeleine + Cruller 04-28, Strudel 04-29) — each ran default `codex` command bypassing `~/.wire/codex-launch.sh`, no Wire MCPs loaded, agent invisible on dashboard
- Re-read on every call; the file is tiny and agent_launch is rare

## Test plan
- [x] In-process probe: write override → load sees it; edit mid-process → reload sees edit; remove → reload sees removal
- [ ] After release + adapter bump + Brioche restart: spawn a codex agent and verify it goes through `~/.wire/codex-launch.sh` (visible in screen process tree)