### PR TITLE
fix: cmux lazy-instantiate + screen path drift + missing screenrc

### DIFF
--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -130,7 +130,11 @@ export class CmuxBackend implements TerminalBackend {
 
   async createTab(_profileName?: string): Promise<string> {
     // profileName is iTerm2-only (dynamic profiles) — cmux ignores it.
-    const output = await cmux("new-workspace");
+    // --focus true is required: cmux 0.64+ lazy-instantiates terminals,
+    // so the workspace's initial surface has no backing PTY until focused.
+    // Without this, attaching screen to the surface fails with
+    // "Surface is not a terminal" / "Terminal surface not found".
+    const output = await cmux("new-workspace", "--focus", "true");
     // Output: "OK workspace:N"
     // We need the surface ref of the new workspace's initial surface.
     // List panes in the new workspace to get it.

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -8,13 +8,23 @@
  */
 
 import { $ } from "bun";
+import { existsSync } from "node:fs";
 import { join } from "path";
 
-// Resolve screen binary: prefer homebrew 5.x (color support) over macOS built-in 4.0
+// Resolve screen binary: prefer homebrew 5.x (color support) over macOS built-in 4.0.
+// macOS screen 4.0 and homebrew screen 5.x use DIFFERENT default socket directories
+// (`/var/folders/.../T/.screen` vs `~/.screen`), so if PATH resolution differs across
+// bun MCP instances, one instance may create sessions invisible to another instance's
+// `screen -ls`. The reconciler then treats live agents as dead and deletes their DB
+// rows. Pinning a known path eliminates that drift.
 async function findScreen(): Promise<string> {
+  const preferred = ["/opt/homebrew/bin/screen", "/usr/local/bin/screen"];
+  for (const path of preferred) {
+    if (existsSync(path)) return path;
+  }
   try {
     const result = await $`command -v screen`.quiet();
-    return result.stdout.toString().trim();
+    return result.stdout.toString().trim() || "screen";
   } catch {
     return "screen";
   }
@@ -39,7 +49,12 @@ export async function createSession(
   // Bun's $ escapes interpolated values, but screen passes remaining args
   // as argv to the child — so "zsh -lc 'cd /a && cmd'" gets split at &&.
   const shell = process.env.SHELL ?? "/bin/zsh";
-  const screenrc = join(process.env.HOME ?? "/tmp", ".wire", "screenrc");
+  const wireDir = join(process.env.HOME ?? "/tmp", ".wire");
+  const screenrc = join(wireDir, "screenrc");
+  // Defensive: `screen -c <missing-file>` fails silently. Ensure the screenrc
+  // exists (empty is fine) so a fresh install — where the wire installer
+  // hasn't yet written this file — doesn't break agent launches.
+  await $`mkdir -p ${wireDir} && touch -a ${screenrc}`.quiet().nothrow();
   const scriptFile = `/tmp/crew-launch-${name}-${Date.now()}.sh`;
   await Bun.write(scriptFile, `#!/usr/bin/env -S ${shell} -l\nrm -f '${scriptFile}'\n${command}\n`);
   await $`chmod +x ${scriptFile}`.quiet();


### PR DESCRIPTION
## Summary

Three small fixes in the agent-launch → pane-attach path, all hit on a fresh install with cmux 0.64.6 + homebrew screen 5.0.1. Each is reproducible and verified at the primitive level.

### 1. `cmux.createTab` doesn't focus the new workspace (`src/cmux.ts`)
cmux 0.64+ lazy-instantiates the workspace's initial surface. The CLI returns a surface ref immediately, but no PTY is attached until the workspace is focused. Without `--focus true`, `agent_attach` later fails with:
```
Error: invalid_params: Surface is not a terminal
```
or via `cmux read-screen --surface surface:N`:
```
Error: internal_error: ERROR: Terminal surface not found
```
**Fix:** pass `--focus true` to `cmux new-workspace`. Verified with `cmux surface-health` showing `in_window=true` immediately after.

### 2. `findScreen` picks whatever's first on PATH (`src/screen.ts`)
The existing comment says it should prefer brew 5.x, but the implementation just returns `command -v screen`. macOS `/usr/bin/screen 4.0` and brew `5.x` use **different default socket directories** (`/var/folders/.../T/.screen` vs `~/.screen`). When multiple bun MCP instances exist (one per CC session, plus stragglers across `/reload-plugins`) and their PATH order differs, an instance can create a session that another instance's `screen -ls` can't see. The reconciler then deletes the "missing" agent rows even though their screen sessions are alive.

**Fix:** prefer `/opt/homebrew/bin/screen` → `/usr/local/bin/screen` → fall back to PATH. Eliminates cross-instance drift.

### 3. `createSession` doesn't tolerate a missing `~/.wire/screenrc` (`src/screen.ts`)
`screen -c <missing-file>` fails silently (returns success but the session never spawns). The wire installer doesn't write `~/.wire/screenrc`, so the very first `agent_launch` on a fresh machine throws:
```
Error: screen session 'wire-scratch' failed to start
```
with no useful diagnostic. Users with a pre-existing `screenrc` (i.e. anyone who installed wire long ago) never hit this.

**Fix:** `touch -a ~/.wire/screenrc` before `screen -c`. Empty file is fine — `-c` just expects a readable path.

## Test plan

- [x] All 99 existing tests pass (`bun test`)
- [x] Patch 1 verified: `cmux new-workspace --focus true` → `surface-health` shows `type=terminal in_window=true`
- [x] Patch 2 verified: `findScreen()` returns `/opt/homebrew/bin/screen` when brew screen is installed
- [x] Patch 3 verified: with empty `~/.wire/screenrc`, `screen -c ~/.wire/screenrc -dmS test bash -c 'echo OK > /tmp/out; sleep 30'` succeeds and the script runs

## Notes

- No version bump — happy to follow your release flow.
- All three fixes are scoped tight; no behavior change for setups that don't hit these conditions.
- Comments in the code call out the root cause so future readers don't have to re-derive it.

🤖 Peace , B.Sweet