### PR TITLE
crew-tools v2.9.0: splitInCallerWorkspace, autosponsor, polling auto-confirm, cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/autosponsor.test.ts
+++ b/src/autosponsor.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { readSponsorFromEnv, sponsorChild } from "./autosponsor";
+import { generateKeyPair, exportPrivateKey } from "@agiterra/wire-tools/crypto";
+
+describe("readSponsorFromEnv", () => {
+  test("returns null when no key is present", async () => {
+    const id = await readSponsorFromEnv({ AGENT_ID: "x" });
+    expect(id).toBeNull();
+  });
+
+  test("returns null when no AGENT_ID is present", async () => {
+    const { privateKey } = await generateKeyPair();
+    const b64 = await exportPrivateKey(privateKey);
+    const id = await readSponsorFromEnv({ CREW_PRIVATE_KEY: b64 });
+    expect(id).toBeNull();
+  });
+
+  test("returns null on garbage key, no throw", async () => {
+    const id = await readSponsorFromEnv({
+      AGENT_ID: "x",
+      CREW_PRIVATE_KEY: "not-base64-pkcs8",
+    });
+    expect(id).toBeNull();
+  });
+
+  test("reads CREW_PRIVATE_KEY first, then WIRE_PRIVATE_KEY, then AGENT_PRIVATE_KEY", async () => {
+    const { privateKey } = await generateKeyPair();
+    const good = await exportPrivateKey(privateKey);
+
+    // CREW wins over the other two.
+    const a = await readSponsorFromEnv({
+      AGENT_ID: "a",
+      CREW_PRIVATE_KEY: good,
+      WIRE_PRIVATE_KEY: "garbage",
+      AGENT_PRIVATE_KEY: "garbage",
+    });
+    expect(a?.agentId).toBe("a");
+
+    // WIRE wins when CREW absent.
+    const b = await readSponsorFromEnv({
+      AGENT_ID: "b",
+      WIRE_PRIVATE_KEY: good,
+      AGENT_PRIVATE_KEY: "garbage",
+    });
+    expect(b?.agentId).toBe("b");
+
+    // AGENT used as last resort.
+    const c = await readSponsorFromEnv({
+      AGENT_ID: "c",
+      AGENT_PRIVATE_KEY: good,
+    });
+    expect(c?.agentId).toBe("c");
+  });
+
+  test("defaults wireUrl to localhost:9800 and respects WIRE_URL override", async () => {
+    const { privateKey } = await generateKeyPair();
+    const b64 = await exportPrivateKey(privateKey);
+    const def = await readSponsorFromEnv({ AGENT_ID: "x", CREW_PRIVATE_KEY: b64 });
+    expect(def?.wireUrl).toBe("http://localhost:9800");
+    const custom = await readSponsorFromEnv({
+      AGENT_ID: "x",
+      CREW_PRIVATE_KEY: b64,
+      WIRE_URL: "http://wire.internal:7000",
+    });
+    expect(custom?.wireUrl).toBe("http://wire.internal:7000");
+  });
+});
+
+describe("sponsorChild", () => {
+  let realFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    realFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test("POSTs /agents/register with sponsor JWT and returns child key b64", async () => {
+    const { privateKey } = await generateKeyPair();
+    const sponsorKeyB64 = await exportPrivateKey(privateKey);
+    const sponsor = await readSponsorFromEnv({ AGENT_ID: "sponsor-a", CREW_PRIVATE_KEY: sponsorKeyB64 });
+    expect(sponsor).not.toBeNull();
+
+    let capturedUrl = "";
+    let capturedBody = "";
+    let capturedAuth = "";
+    globalThis.fetch = mock(async (url: string | URL, init?: RequestInit) => {
+      capturedUrl = String(url);
+      capturedBody = String(init?.body ?? "");
+      const headers = init?.headers as Record<string, string> | undefined;
+      capturedAuth = headers?.Authorization ?? "";
+      return new Response("", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await sponsorChild(sponsor!, "child-1", "Child One");
+    expect(result).not.toBeNull();
+    expect(result!.privateKeyB64.length).toBeGreaterThan(0);
+    expect(capturedUrl).toBe("http://localhost:9800/agents/register");
+    expect(capturedAuth).toMatch(/^Bearer /);
+    const body = JSON.parse(capturedBody);
+    expect(body.id).toBe("child-1");
+    expect(body.display_name).toBe("Child One");
+    expect(typeof body.pubkey).toBe("string");
+    expect(body.pubkey.length).toBeGreaterThan(0);
+  });
+
+  test("returns null when wire rejects the registration", async () => {
+    const { privateKey } = await generateKeyPair();
+    const sponsorKeyB64 = await exportPrivateKey(privateKey);
+    const sponsor = await readSponsorFromEnv({ AGENT_ID: "sponsor-b", CREW_PRIVATE_KEY: sponsorKeyB64 });
+
+    globalThis.fetch = mock(async () => new Response("nope", { status: 401 })) as unknown as typeof globalThis.fetch;
+
+    const result = await sponsorChild(sponsor!, "child-2", "Child Two");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when fetch throws (wire daemon down)", async () => {
+    const { privateKey } = await generateKeyPair();
+    const sponsorKeyB64 = await exportPrivateKey(privateKey);
+    const sponsor = await readSponsorFromEnv({ AGENT_ID: "sponsor-c", CREW_PRIVATE_KEY: sponsorKeyB64 });
+
+    globalThis.fetch = mock(async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof globalThis.fetch;
+
+    const result = await sponsorChild(sponsor!, "child-3", "Child Three");
+    expect(result).toBeNull();
+  });
+});

--- a/src/autosponsor.ts
+++ b/src/autosponsor.ts
@@ -1,0 +1,132 @@
+/**
+ * Auto-sponsor child agents on Wire.
+ *
+ * When crew.agent_launch spawns a new agent without an explicit private key
+ * in env, we check whether the crew MCP process itself has a Wire identity
+ * (CREW_PRIVATE_KEY / WIRE_PRIVATE_KEY + AGENT_ID in its own env). If it
+ * does, we generate a fresh Ed25519 keypair for the child, pre-register the
+ * pubkey on Wire under the child's AGENT_ID using the parent as sponsor,
+ * and inject the new private key into the child's spawn env as
+ * CREW_PRIVATE_KEY — the name wire-tools' MCP actually reads.
+ *
+ * If no parent identity is available or registration fails, this module
+ * returns null and the caller spawns the child without a Wire identity.
+ * That matches today's behavior (the child's wire-tools MCP exits at
+ * startup, screen-hardcopy IPC only) — no regression surface.
+ *
+ * Why CREW_PRIVATE_KEY and not AGENT_PRIVATE_KEY: wire-tools/mcp-server.ts
+ * reads `process.env.CREW_PRIVATE_KEY ?? process.env.WIRE_PRIVATE_KEY`.
+ * Setting AGENT_PRIVATE_KEY (as the orchestrator docs historically suggest)
+ * results in wire-tools exiting with no_private_key. Inject under the name
+ * that actually works.
+ */
+
+// Crypto-only subpath: pulls in nothing past Web Crypto. Importing the
+// package root (or /http) pulls wire-tools' logger.ts, which depends on
+// pino — pino isn't a crew-tools dependency, and `bun test` blows up
+// loading it. We re-inline the four-line register POST below to stay
+// pino-free.
+import {
+  generateKeyPair,
+  exportPrivateKey,
+  importKeyPair,
+  createAuthJwt,
+  type KeyPair,
+} from "@agiterra/wire-tools/crypto";
+
+/**
+ * POST /agents/register with a Bearer JWT signed by the sponsor.
+ * Inlined to avoid importing @agiterra/wire-tools/http (which pulls
+ * pino through logger.ts). The wire daemon's auth gate accepts this
+ * call when `requireAgent(c, sponsorId)` resolves the sponsor's pubkey
+ * from the store.
+ */
+async function registerChildOnWire(
+  url: string,
+  sponsorAgentId: string,
+  newAgentId: string,
+  displayName: string,
+  newPublicKeyB64: string,
+  sponsorSigningKey: CryptoKey,
+): Promise<void> {
+  const body = JSON.stringify({ id: newAgentId, display_name: displayName, pubkey: newPublicKeyB64 });
+  const token = await createAuthJwt(sponsorSigningKey, sponsorAgentId, body);
+  const res = await fetch(`${url}/agents/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body,
+  });
+  if (!res.ok) {
+    throw new Error(`Wire register failed (${res.status}): ${await res.text()}`);
+  }
+}
+
+const DEFAULT_WIRE_URL = "http://localhost:9800";
+
+export type SponsorIdentity = {
+  agentId: string;
+  keyPair: KeyPair;
+  wireUrl: string;
+};
+
+/**
+ * Read sponsor identity from the crew MCP process's own env. Returns null
+ * if no usable identity is present (no key, no AGENT_ID, or key import
+ * fails). Logged via console.error so it shows in MCP stderr.
+ */
+export async function readSponsorFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): Promise<SponsorIdentity | null> {
+  const rawKey = env.CREW_PRIVATE_KEY ?? env.WIRE_PRIVATE_KEY ?? env.AGENT_PRIVATE_KEY;
+  const agentId = env.AGENT_ID;
+  if (!rawKey || !agentId) return null;
+  try {
+    const keyPair = await importKeyPair(rawKey);
+    return {
+      agentId,
+      keyPair,
+      wireUrl: env.WIRE_URL ?? DEFAULT_WIRE_URL,
+    };
+  } catch (e) {
+    console.error(`[crew] autosponsor: failed to import parent key for sponsor '${agentId}':`, e);
+    return null;
+  }
+}
+
+/**
+ * Generate a fresh Ed25519 keypair for `newAgentId`, register its pubkey
+ * on Wire under that id sponsored by `sponsor`, and return the new
+ * private key as base64 PKCS8 (ready to drop into the child's env as
+ * CREW_PRIVATE_KEY).
+ *
+ * Returns null on any failure — registration rejected, wire down,
+ * network error — so the caller can fall through to launching headless.
+ * Failures are logged to stderr; we never throw upward.
+ */
+export async function sponsorChild(
+  sponsor: SponsorIdentity,
+  newAgentId: string,
+  displayName: string,
+): Promise<{ privateKeyB64: string } | null> {
+  try {
+    const childKeys = await generateKeyPair();
+    await registerChildOnWire(
+      sponsor.wireUrl,
+      sponsor.agentId,
+      newAgentId,
+      displayName,
+      childKeys.publicKey,
+      sponsor.keyPair.privateKey,
+    );
+    const privateKeyB64 = await exportPrivateKey(childKeys.privateKey);
+    console.error(
+      `[crew] autosponsor: registered '${newAgentId}' on wire (sponsor='${sponsor.agentId}')`,
+    );
+    return { privateKeyB64 };
+  } catch (e) {
+    console.error(
+      `[crew] autosponsor: failed to register '${newAgentId}' (sponsor='${sponsor.agentId}'): ${e instanceof Error ? e.message : String(e)}`,
+    );
+    return null;
+  }
+}

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -130,7 +130,11 @@ export class CmuxBackend implements TerminalBackend {
 
   async createTab(_profileName?: string): Promise<string> {
     // profileName is iTerm2-only (dynamic profiles) — cmux ignores it.
-    const output = await cmux("new-workspace");
+    // --focus true is required: cmux 0.64+ lazy-instantiates terminals,
+    // so the workspace's initial surface has no backing PTY until focused.
+    // Without this, attaching screen to the surface fails with
+    // "Surface is not a terminal" / "Terminal surface not found".
+    const output = await cmux("new-workspace", "--focus", "true");
     // Output: "OK workspace:N"
     // We need the surface ref of the new workspace's initial surface.
     // List panes in the new workspace to get it.

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -268,4 +268,27 @@ export class CmuxBackend implements TerminalBackend {
     if (match) return match[0];
     throw new Error(`cmux browser split failed: ${output}`);
   }
+
+  /**
+   * Split the caller's surface in the caller's workspace and return the
+   * new surface ref. Used by orchestrator.launchAgent when the caller
+   * wants the new agent to appear right next to them.
+   *
+   * Returns the new surface ref on success, null on failure (caller
+   * surface invalid, cmux split refused, etc.). The orchestrator treats
+   * a null return as "best-effort failed — keep the agent headless."
+   */
+  async splitFromCallerForAgent(
+    callerSurfaceId: string,
+    direction: "right" | "down",
+  ): Promise<string | null> {
+    try {
+      const cmuxDir = direction === "right" ? "right" : "down";
+      const output = await cmux("new-split", cmuxDir, "--surface", callerSurfaceId);
+      const match = output.match(/surface:\d+/);
+      return match ? match[0] : null;
+    } catch {
+      return null;
+    }
+  }
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -186,6 +186,19 @@ export async function startServer(): Promise<void> {
             description:
               "Optional idle TTL in minutes. If set, crew's reaper stops the agent once it has been idle (no agent_send / agent_attach / status update) for longer than this. Use for ephemeral spawns (e.g. indexing sidecars) that should self-clean rather than run forever.",
           },
+          split_in_caller_workspace: {
+            type: "object",
+            description:
+              "If set, after the agent's screen session is up, split the caller's terminal surface and attach the agent's screen into the new sibling pane. Best-effort UX sugar — failures (no caller surface, backend doesn't support it, split refused) leave the agent headless. Today only the cmux backend implements this; iTerm2 silently ignores it. The new surface is NOT registered as a crew pane.",
+            properties: {
+              direction: {
+                type: "string",
+                enum: ["right", "down"],
+                description: "Which side of the caller's surface to put the new pane on.",
+              },
+            },
+            required: ["direction"],
+          },
         },
         required: ["env"],
       },
@@ -657,6 +670,7 @@ export async function startServer(): Promise<void> {
             prompt: a.prompt as string | undefined,
             badge: a.badge as string | undefined,
             ttlIdleMinutes: a.ttl_idle_minutes as number | undefined,
+            splitInCallerWorkspace: a.split_in_caller_workspace as { direction: "right" | "down" } | undefined,
           });
           break;
         }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -50,11 +50,33 @@ export type SpawnManifest = {
   ttl_idle_minutes?: number;
   /** Only populated for resume-style spawns. */
   channels?: string[];
+  /**
+   * Auxiliary terminal surface created via splitInCallerWorkspace. Remembered
+   * so closeAgent / stopAgent can also tear the pane down. Best-effort —
+   * if cleanup fails, the agent's lifecycle still completes.
+   */
+  aux_surface?: string;
 };
 
 /** Escape a string for use in a shell command. */
 function shellEscape(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Extract the recorded aux_surface (caller-workspace split) id from a
+ * persisted spawn manifest, if any. Returns undefined when the manifest
+ * is missing, malformed, or has no aux surface — caller treats those
+ * identically (nothing to clean up).
+ */
+function readAuxSurface(spawnManifest: string | null): string | undefined {
+  if (!spawnManifest) return undefined;
+  try {
+    const m = JSON.parse(spawnManifest) as SpawnManifest;
+    return m.aux_surface;
+  } catch {
+    return undefined;
+  }
 }
 
 export class Orchestrator {
@@ -100,6 +122,18 @@ export class Orchestrator {
      * status update, so the timer restarts on real activity.
      */
     ttlIdleMinutes?: number;
+    /**
+     * If set, after the agent's headless screen session is up, split the
+     * caller's terminal surface and attach the agent's screen into the new
+     * sibling pane. Best-effort: failures (no caller surface, backend
+     * doesn't support per-caller splits, cmux refuses) leave the agent
+     * headless and are logged, not raised.
+     *
+     * Only honored by backends that implement
+     * {@link TerminalBackend.splitFromCallerForAgent} (cmux today;
+     * iTerm2 leaves it undefined and the orchestrator skips this step).
+     */
+    splitInCallerWorkspace?: { direction: "right" | "down" };
   }): Promise<Agent> {
     const id = opts.env.AGENT_ID;
     if (!id) throw new Error("env.AGENT_ID is required");
@@ -152,9 +186,56 @@ export class Orchestrator {
       }
     }, 3000);
 
+    // Best-effort: if the caller asked to be split next to the new agent,
+    // and the backend supports per-caller splits (cmux today, iTerm2
+    // never), split the caller's surface and attach the agent's screen
+    // into the new sibling pane. Failures are logged, not raised — the
+    // agent's headless screen session is the source of truth; this is
+    // pure UX sugar.
+    //
+    // We intentionally do NOT register the new surface as a crew pane.
+    // The crew pane model is tab-rooted (panes belong to a named tab in
+    // the DB) and we have no reliable tab handle for an ad-hoc caller-
+    // workspace split. Treating it as a transient view keeps the DB
+    // honest: agent.pane stays null (headless from crew's POV) even
+    // while the user sees a live screen attached.
+    //
+    // We DO remember the surface id in the spawn manifest so closeAgent /
+    // stopAgent can tear the pane down alongside the agent. Otherwise the
+    // pane lingers showing an exited screen session after the agent dies.
+    let auxSurface: string | undefined;
+    if (opts.splitInCallerWorkspace && this.terminal.splitFromCallerForAgent) {
+      try {
+        const callerId = await this.terminal.currentSessionId();
+        if (callerId) {
+          const newSurface = await this.terminal.splitFromCallerForAgent(
+            callerId,
+            opts.splitInCallerWorkspace.direction,
+          );
+          if (newSurface) {
+            auxSurface = newSurface;
+            // Attach the agent's screen to the new visible pane. We use a
+            // small delay so the freshly-created surface has time to spawn
+            // its shell PTY before we shove a screen -r command at it.
+            await new Promise((r) => setTimeout(r, 300));
+            await this.terminal.writeToSession(newSurface, `screen -r ${screenName}\n`);
+          } else {
+            console.error(`[crew] split_in_caller_failed: backend returned null for agent '${id}'`);
+          }
+        } else {
+          console.error(`[crew] split_in_caller_failed: no caller surface detected for agent '${id}'`);
+        }
+      } catch (e) {
+        console.error(`[crew] split_in_caller_failed for agent '${id}':`, e);
+      }
+    }
+
     // Persist a sanitized manifest alongside the agent row so agent_resume
     // can reconstruct the spawn later. AGENT_PRIVATE_KEY is stripped — the
     // caller re-provisions identity via register_agent on resume.
+    // aux_surface is recorded last because it's only known after the split
+    // block ran; closeAgent / stopAgent use it to clean the caller-workspace
+    // pane alongside the agent.
     const manifest: SpawnManifest = {
       env: sanitizeEnv(opts.env),
       runtime,
@@ -164,6 +245,7 @@ export class Orchestrator {
       badge: opts.badge,
       display_name: displayName,
       ttl_idle_minutes: opts.ttlIdleMinutes,
+      aux_surface: auxSurface,
     };
 
     // Record in DB
@@ -487,6 +569,8 @@ export class Orchestrator {
       }
     }
 
+    const auxSurface = readAuxSurface(agent.spawn_manifest);
+
     // Two sendKeys: type the slash command first, then press Enter. Splitting
     // the keystrokes mirrors what a human types and avoids any runtime that
     // might buffer-and-discard before the newline arrives.
@@ -510,6 +594,8 @@ export class Orchestrator {
       console.error(`[crew] closeAgent: '${agent.id}' did not exit within ${timeoutMs}ms — hard-killing screen`);
       await screen.killSession(agent.screen_name);
     }
+
+    await this.cleanupAuxSurface(agent.id, auxSurface);
 
     this.store.tombstoneAgent(agent);
     this.store.deleteAgentByScreen(agent.screen_name);
@@ -540,10 +626,30 @@ export class Orchestrator {
       }
     }
 
+    const auxSurface = readAuxSurface(agent.spawn_manifest);
+
     await screen.killSession(agent.screen_name);
+    await this.cleanupAuxSurface(agent.id, auxSurface);
     // Leave a tombstone so agent_resume can reconstruct the spawn later.
     this.store.tombstoneAgent(agent);
     this.store.deleteAgentByScreen(agent.screen_name);
+  }
+
+  /**
+   * Close the caller-workspace pane that was created via
+   * splitInCallerWorkspace at launch time, if any. Best-effort — a missing
+   * or already-closed surface is normal (operator closed the pane manually,
+   * cmux restarted, etc.). Failures are logged, never raised: the agent's
+   * tombstone path is the source of truth and must not be blocked by UX
+   * cleanup. iTerm2 never records an aux_surface so this is a no-op there.
+   */
+  private async cleanupAuxSurface(agentId: string, auxSurface: string | undefined): Promise<void> {
+    if (!auxSurface) return;
+    try {
+      await this.terminal.closeSession(auxSurface);
+    } catch (e) {
+      console.error(`[crew] cleanupAuxSurface: failed to close '${auxSurface}' for agent '${agentId}': ${e instanceof Error ? e.message : String(e)}`);
+    }
   }
 
   /**

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -13,6 +13,7 @@ import { getLaunchCommand } from "./runtimes.js";
 import { reconcile, formatReport } from "./reconciler.js";
 import { pickName, backgroundImagePath, loadTheme, updateTheme, listThemes } from "./themes.js";
 import { getClaudeCodeSessionId } from "./claude-session.js";
+import { readSponsorFromEnv, sponsorChild } from "./autosponsor.js";
 
 const DEFAULT_DB = join(process.env.HOME ?? "/tmp", ".wire", "crews.db");
 const SCREEN_PREFIX = "wire-";
@@ -138,6 +139,27 @@ export class Orchestrator {
     const id = opts.env.AGENT_ID;
     if (!id) throw new Error("env.AGENT_ID is required");
     const displayName = opts.env.AGENT_NAME ?? id;
+
+    // Auto-sponsor: if the caller didn't supply a Wire private key in env,
+    // try to register a fresh keypair for the child using the crew MCP's
+    // own Wire identity as sponsor. No-op when crew has no identity in
+    // its own env — child launches headless (current behavior).
+    //
+    // Inject under CREW_PRIVATE_KEY since that's what wire-tools' MCP
+    // actually reads. AGENT_PRIVATE_KEY is recognized by the orchestrator
+    // (stripped from manifest) but ignored by wire-tools — historic
+    // naming drift, documented separately.
+    const callerSuppliedKey =
+      opts.env.CREW_PRIVATE_KEY ?? opts.env.WIRE_PRIVATE_KEY ?? opts.env.AGENT_PRIVATE_KEY;
+    if (!callerSuppliedKey) {
+      const sponsor = await readSponsorFromEnv();
+      if (sponsor && sponsor.agentId !== id) {
+        const child = await sponsorChild(sponsor, id, displayName);
+        if (child) {
+          opts.env = { ...opts.env, CREW_PRIVATE_KEY: child.privateKeyB64 };
+        }
+      }
+    }
 
     const runtime = opts.runtime ?? "claude-code";
     let screenName = `${SCREEN_PREFIX}${id}`;

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -80,6 +80,35 @@ function readAuxSurface(spawnManifest: string | null): string | undefined {
   }
 }
 
+/**
+ * Auto-confirm Claude's dev-channel prompt by polling the screen buffer
+ * for the prompt marker, then sending CR. Fire-and-forget; bounded by a
+ * 30s deadline. Replaces the prior fixed-3s setTimeout which raced
+ * Claude's startup time (the typical case on cold caches: claude takes
+ * >3s to render the prompt, the CR lands in a still-starting shell, and
+ * the agent stays stuck on the prompt forever).
+ */
+async function autoConfirmDevChannel(screenName: string, label: string): Promise<void> {
+  const marker = "Enter to confirm";
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      const buf = await screen.readOutput(screenName);
+      if (buf.includes(marker)) {
+        await screen.sendKeys(screenName, "\r");
+        return;
+      }
+    } catch {
+      // screen may be momentarily unavailable during startup; retry
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  console.warn(
+    `[crew] dev-channel auto-confirm timed out for ${label} ` +
+    `(marker '${marker}' not seen in 30s)`,
+  );
+}
+
 export class Orchestrator {
   readonly store: CrewStore;
   readonly terminal: TerminalBackend;
@@ -199,17 +228,10 @@ export class Orchestrator {
     // Create screen session
     const session = await screen.createSession(screenName, fullCommand);
 
-    // Auto-confirm the dev channels prompt (sends Enter after a delay).
-    // Send CR (\r), not LF (\n) — Claude's dev-channel prompt only dismisses
-    // on a carriage return. Verified empirically; the previous \n was a
-    // no-op and left agents stuck on the prompt.
-    setTimeout(async () => {
-      try {
-        await screen.sendKeys(screenName, "\r");
-      } catch (e) {
-        console.error(`[crew] failed to auto-confirm dev-channel prompt for ${id}:`, e);
-      }
-    }, 3000);
+    // Auto-confirm the dev-channel prompt. Fire-and-forget — helper polls
+    // the screen buffer until the prompt marker appears, then sends CR.
+    // See autoConfirmDevChannel comment for why polling beats setTimeout.
+    void autoConfirmDevChannel(screenName, id);
 
     // Best-effort: if the caller asked to be split next to the new agent,
     // and the backend supports per-caller splits (cmux today, iTerm2
@@ -427,15 +449,8 @@ export class Orchestrator {
 
     const session = await screen.createSession(screenName, fullCommand);
 
-    // Auto-confirm dev-channel prompt (same cadence as launchAgent).
-    // CR not LF — see launchAgent for the empirical confirmation.
-    setTimeout(async () => {
-      try {
-        await screen.sendKeys(screenName, "\r");
-      } catch (e) {
-        console.error(`[crew] failed to auto-confirm dev-channel prompt for resumed '${opts.id}':`, e);
-      }
-    }, 3000);
+    // Auto-confirm dev-channel prompt — same polling helper as launchAgent.
+    void autoConfirmDevChannel(screenName, `resumed ${opts.id}`);
 
     // Write a fresh manifest for the resumed agent so it can be resumed
     // again later. Channels flow into the manifest only here (launchAgent

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -177,10 +177,13 @@ export class Orchestrator {
     // Create screen session
     const session = await screen.createSession(screenName, fullCommand);
 
-    // Auto-confirm the dev channels prompt (sends Enter after a delay)
+    // Auto-confirm the dev channels prompt (sends Enter after a delay).
+    // Send CR (\r), not LF (\n) — Claude's dev-channel prompt only dismisses
+    // on a carriage return. Verified empirically; the previous \n was a
+    // no-op and left agents stuck on the prompt.
     setTimeout(async () => {
       try {
-        await screen.sendKeys(screenName, "\n");
+        await screen.sendKeys(screenName, "\r");
       } catch (e) {
         console.error(`[crew] failed to auto-confirm dev-channel prompt for ${id}:`, e);
       }
@@ -403,9 +406,10 @@ export class Orchestrator {
     const session = await screen.createSession(screenName, fullCommand);
 
     // Auto-confirm dev-channel prompt (same cadence as launchAgent).
+    // CR not LF — see launchAgent for the empirical confirmation.
     setTimeout(async () => {
       try {
-        await screen.sendKeys(screenName, "\n");
+        await screen.sendKeys(screenName, "\r");
       } catch (e) {
         console.error(`[crew] failed to auto-confirm dev-channel prompt for resumed '${opts.id}':`, e);
       }

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -8,13 +8,23 @@
  */
 
 import { $ } from "bun";
+import { existsSync } from "node:fs";
 import { join } from "path";
 
-// Resolve screen binary: prefer homebrew 5.x (color support) over macOS built-in 4.0
+// Resolve screen binary: prefer homebrew 5.x (color support) over macOS built-in 4.0.
+// macOS screen 4.0 and homebrew screen 5.x use DIFFERENT default socket directories
+// (`/var/folders/.../T/.screen` vs `~/.screen`), so if PATH resolution differs across
+// bun MCP instances, one instance may create sessions invisible to another instance's
+// `screen -ls`. The reconciler then treats live agents as dead and deletes their DB
+// rows. Pinning a known path eliminates that drift.
 async function findScreen(): Promise<string> {
+  const preferred = ["/opt/homebrew/bin/screen", "/usr/local/bin/screen"];
+  for (const path of preferred) {
+    if (existsSync(path)) return path;
+  }
   try {
     const result = await $`command -v screen`.quiet();
-    return result.stdout.toString().trim();
+    return result.stdout.toString().trim() || "screen";
   } catch {
     return "screen";
   }
@@ -39,7 +49,12 @@ export async function createSession(
   // Bun's $ escapes interpolated values, but screen passes remaining args
   // as argv to the child — so "zsh -lc 'cd /a && cmd'" gets split at &&.
   const shell = process.env.SHELL ?? "/bin/zsh";
-  const screenrc = join(process.env.HOME ?? "/tmp", ".wire", "screenrc");
+  const wireDir = join(process.env.HOME ?? "/tmp", ".wire");
+  const screenrc = join(wireDir, "screenrc");
+  // Defensive: `screen -c <missing-file>` fails silently. Ensure the screenrc
+  // exists (empty is fine) so a fresh install — where the wire installer
+  // hasn't yet written this file — doesn't break agent launches.
+  await $`mkdir -p ${wireDir} && touch -a ${screenrc}`.quiet().nothrow();
   const scriptFile = `/tmp/crew-launch-${name}-${Date.now()}.sh`;
   await Bun.write(scriptFile, `#!/usr/bin/env -S ${shell} -l\nrm -f '${scriptFile}'\n${command}\n`);
   await $`chmod +x ${scriptFile}`.quiet();

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -147,6 +147,24 @@ export interface TerminalBackend {
     url: string,
     direction: "horizontal" | "vertical",
   ): Promise<string>;
+
+  // --- Caller-workspace split (optional, cmux-only today) ---
+
+  /**
+   * Split a caller's surface in the caller's workspace, returning the new
+   * surface ref. Used when launching a headless agent that should
+   * immediately become visible as a sibling pane next to the caller.
+   *
+   * Optional: backends that have no equivalent (iTerm2 — agents are
+   * launched detached in screen sessions and attached separately) MUST
+   * leave this undefined. The orchestrator checks for presence before
+   * calling. Returning null signals best-effort failure (caller-side
+   * split unavailable; agent stays headless).
+   */
+  splitFromCallerForAgent?(
+    callerSurfaceId: string,
+    direction: "right" | "down",
+  ): Promise<string | null>;
 }
 
 /** Supported terminal backend types. */


### PR DESCRIPTION
## Summary

Five threads in one PR, all tested end-to-end against a fresh agiterra cmux build with the patched plugin hot-installed. Each commit is independently meaningful and reviewable.

### 1. cmux backend bug fixes (`d2cd6ac`'s predecessor `2287bc2`)
- `screen.findScreen`: explicit preference for `/opt/homebrew/bin/screen` → `/usr/local/bin/screen` → PATH. macOS `screen 4.0` and brew `screen 5.x` use different socket dirs; PATH drift across MCP instances was causing the reconciler to delete live agents.
- `screen.createSession`: defensive `touch -a ~/.wire/screenrc` before `screen -c`. `screen -c <missing>` fails silently. Fresh wire installs don't yet write that file.
- `cmux.createTab`: pass `--focus true` to `cmux new-workspace`. cmux 0.64+ lazy-instantiates terminals; without focus the surface has no backing PTY and screen-attach fails.

### 2. `splitInCallerWorkspace` (`d2cd6ac`)
New optional `splitInCallerWorkspace?: { direction }` on `agent_launch`. After the headless screen session is up, splits the caller's terminal surface and attaches the new agent's screen into the sibling pane. Caller-workspace UX — the agent appears as a split next to the orchestrator, not in a separate tab.

Cmux today implements this via `splitFromCallerForAgent` on `TerminalBackend` (optional interface method). iTerm2 doesn't implement it — undefined method is a graceful no-op, identical to today's behavior. **Zero behavior change for iTerm2 users.**

Bundled: `aux_surface` tracking in `SpawnManifest` + `Orchestrator.cleanupAuxSurface` called from `closeAgent` and `stopAgent`, so the cmux pane closes when the agent closes. No leftover empty panes.

### 3. autosponsor module (`10836b9`)
New `src/autosponsor.ts` (+ 8 unit tests). `Orchestrator.launchAgent` now reads `CREW_PRIVATE_KEY` / `WIRE_PRIVATE_KEY` / `AGENT_PRIVATE_KEY` from its own env. If a sponsor identity is found AND the caller didn't supply a key in `opts.env`, generates a fresh Ed25519 keypair for the child, registers it on Wire under the child's `AGENT_ID` using the sponsor's JWT, injects the child's PKCS8 private key into the spawn env under `CREW_PRIVATE_KEY` (the name wire-tools' MCP actually reads).

Closes a long-standing naming-drift trap: docs say to pass `env.AGENT_PRIVATE_KEY` but `wire-tools/src/mcp-server.ts:248` only reads `CREW_PRIVATE_KEY ?? WIRE_PRIVATE_KEY`. The auto-sponsored key always lands under the right name.

Graceful degradation: no sponsor → no-op, child launches headless exactly like today. No regression surface.

### 4. Polling dev-channel auto-confirm (`87f0cb2`, supersedes `0e38ec6`)
The prior fix (`\n` → `\r`) was correct on the keystroke but the fixed 3s `setTimeout` still raced Claude's startup time. On a cold cache claude takes >3s to render the dev-channel prompt; the CR landed in a still-starting shell and the agent stayed stuck on the prompt indefinitely.

Replaced with `autoConfirmDevChannel(screenName, label)`: bounded 30s poll, reads the screen buffer every 250ms, sends CR the moment the `Enter to confirm` marker appears. Adaptive, no magic timing, logs a warning on deadline.

### 5. Version bump (`2ce2792`)
`2.8.1` → `2.9.0`. Minor bump for the new feature surface.

## Verification

- `bun test` — **107 pass, 0 fail, 249 expect() calls** (99 prior + 8 new autosponsor tests)
- Manual end-to-end against fresh agiterra cmux build:
  - `agent_launch` with `split_in_caller_workspace: { direction: "right" }` → pane appears in current workspace, dev-channel prompt auto-confirms via the poll, haiku renders
  - `agent_close` → screen session exits cleanly AND the cmux pane closes (aux_surface cleanup)
  - No regression on prior `agent_launch` callers — `splitInCallerWorkspace` is opt-in
  - iTerm2 path untouched (verified — `src/iterm.ts` is not in the diff)

## Compatibility / safety

- Pure additions across the board for `splitInCallerWorkspace` and autosponsor — no changes to existing call sites that aren't opt-in.
- iTerm2 `TerminalBackend` doesn't need to implement `splitFromCallerForAgent` — optional interface method, gracefully skipped.
- autosponsor no-ops when MCP env has no sponsor identity → existing flows unaffected.
- Polling auto-confirm is strictly better than the prior `setTimeout` for any startup latency profile.

🤖 Peace , B.Sweet