### PR TITLE
docs: clean stale autosponsor + wire-ipc cross-refs from MCP docstrings (v2.10.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -174,7 +174,7 @@ export async function startServer(): Promise<void> {
               "Env vars exported into the spawned agent's environment. " +
               "MUST include AGENT_ID — crew uses it as the agent's primary identifier (screen session name, DB key). AGENT_NAME defaults to AGENT_ID. " +
               "All other vars are opaque to crew. " +
-              "For Wire-using agents include AGENT_PRIVATE_KEY: orchestrator generates the keypair, pre-registers the public key on Wire (sponsoring-agent register flow), and passes the base64 PKCS8 private key here.",
+              "For Wire-using agents, include AGENT_PRIVATE_KEY. The orchestrator is responsible for provisioning the keypair BEFORE calling agent_launch — typically by calling `mcp__plugin_wire_wire__register_agent({ id })` (fresh mode mints a keypair and returns `private_key_b64`) and passing that string here as base64 PKCS8. Crew itself does NOT register, sponsor, or generate keys; it only forwards the env map verbatim to the spawned process. (The v2.9.x `autosponsor` shortcut was removed in v2.10.0 per the cross-refs rule — composite register+spawn workflows belong in a bundle plugin, not in crew-tools.)",
           },
           prompt: { type: "string", description: "Initial prompt — passed as positional arg to the runtime command." },
           runtime: { type: "string", description: "Runtime: claude-code, codex, etc. Default: claude-code" },
@@ -234,8 +234,9 @@ export async function startServer(): Promise<void> {
         "call — no re-supplying inputs.\n\n" +
         "Wire identity: AGENT_PRIVATE_KEY is stripped from the stored " +
         "manifest, so if the agent uses Wire, first call " +
-        "`register_agent` (from wire-ipc) to rotate the keypair on Wire, " +
-        "then pass the new key as `env.AGENT_PRIVATE_KEY` here. Wire's " +
+        "`mcp__plugin_wire_wire__register_agent({ id, force_rotate: true })` to mint a fresh keypair on Wire " +
+        "(the `register_agent` tool moved from wire-ipc to the wire plugin in wire-ipc v1.3.0), " +
+        "then pass the returned `private_key_b64` as `env.AGENT_PRIVATE_KEY` here. Wire's " +
         "/agents/register is UPSERT keyed on id, so the same agent id " +
         "continues to exist with a new pubkey.\n\n" +
         "Any explicit field overrides the tombstone's value (including " +


### PR DESCRIPTION
## What

Fix two lingering references to the removed v2.9.x `autosponsor` feature that misrepresent crew-tools' contract. After [`5e20d633`](https://github.com/agiterra/crew-tools/commit/5e20d633) (`v2.10.0: remove autosponsor — wrong layer`) and [`7af4736d`](https://github.com/agiterra/crew-tools/commit/7af4736d) (`Drop 'autosponsor' from comments — cruft`), the runtime behavior is correct but two user-facing docstrings still phrase identity provisioning as if crew does something — leading users to expect an auto-register path that no longer exists.

## Why this matters

A real operator (`alex` on Brian Sweet's setup) hit this today: read the `agent_launch` docstring's `sponsoring-agent register flow` phrasing, assumed crew was handling registration, called `agent_launch` with `AGENT_PRIVATE_KEY=''` expecting autogen, and ended up debugging a 403 `unknown sender: alex-sponsor` error for an identity that doesn't exist anywhere in the codebase. The phrase is a vestige of the v2.9.x autosponsor era; the contract is now orchestrator-driven and the docs should say so explicitly.

## Verification

**Repo / refs**
- Repo: `agiterra/crew-tools`
- Base: `main` at `c37420cc` = tag `v2.10.1`
- Pinned by `crew-claude-code` v2.7.2 (`@agiterra/crew-tools#v2.10.1` in `package.json`)
- Local `node_modules/.../mcp-server.ts` byte-identical to upstream at v2.10.1 (verified `diff -u`)

**In-flight fixes? No.**
- `gh pr list -R agiterra/crew-tools --state open` → `[]`
- No open feat/ or fix/ branches mention docs, docstring, or sponsor
- Commit chain: `fd73ef4e` add autosponsor → `5e20d633` remove autosponsor → `7af4736d` drop autosponsor cruft. No follow-up doc pass landed.

**Three sites identified, two fixed here:**

1. **`src/mcp-server.ts:177`** — `agent_launch` env.AGENT_PRIVATE_KEY description. Jargon-y `sponsoring-agent register flow` phrase reads like crew does it. **Fixed in this PR.**
2. **`src/mcp-server.ts:237`** — `agent_resume` description references `register_agent (from wire-ipc)`. **STALE**: `register_agent` moved to the `wire` plugin in wire-ipc v1.3.0 (confirmed by `@agiterra/wire-ipc-tools/src/mcp-server.ts:48` and `wire-ipc-tools/README.md:31` both redirecting). **Fixed in this PR.**
3. `crew-claude-code` repo `README.md:100` — same `sponsoring-agent register flow` phrasing in the `Spawning Wire-using agents` section. **Addressed in companion PR [agiterra/crew-claude-code#34](https://github.com/agiterra/crew-claude-code/pull/34).**

## Diff

See the two-line+ change in `src/mcp-server.ts`. Phrasing follows the canonical workflow:

> `mcp__plugin_wire_wire__register_agent({ id })` (fresh mode mints + returns `private_key_b64`) → pass to `agent_launch` `env.AGENT_PRIVATE_KEY`.

Same pattern for the `force_rotate: true` resume variant.

## Test plan

- [x] `bun test` → 99 pass / 0 fail (unchanged)
- [x] No remaining `sponsoring-agent register flow` strings in repo: `git grep "sponsoring-agent"` → clean
- [x] No remaining `(from wire-ipc)` cross-refs for `register_agent`: `git grep "register_agent.*wire-ipc"` → clean
- [x] Version bumped to `v2.10.2` (docs-only patch)

## Credit

Diagnosed via live wire consult with `fondant` (on `alex@brian-dev`'s local wire, `localhost:9800`). Fondant verified upstream methodically — checked main HEAD vs v2.10.1, scanned open PRs/branches for in-flight fixes, traced the autosponsor removal commit chain, and produced this exact PR body.

🧰 Fondant
🧭 alex
🤖 B.Sweet