### PR TITLE
feat: zero-prompt CC ephemerals (workspace-trust pre-accept + dual auto-confirm)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -80,32 +80,75 @@ function readAuxSurface(spawnManifest: string | null): string | undefined {
 }
 
 /**
+ * Pre-accept Claude Code's workspace-trust dialog for the given project
+ * directory by writing `projects[cwd].hasTrustDialogAccepted = true` into
+ * ~/.claude.json before the agent starts. Without this, every newly-cd'd
+ * ephemeral hits a separate confirmation dialog that bypassPermissions
+ * doesn't bypass.
+ *
+ * Best-effort: errors are logged and swallowed. The agent will still spawn
+ * and the user can manually accept the dialog as a fallback.
+ */
+async function preAcceptWorkspaceTrust(projectDir: string): Promise<void> {
+  const cfgPath = `${process.env.HOME ?? ""}/.claude.json`;
+  try {
+    const fs = await import("fs/promises");
+    let cfg: { projects?: Record<string, Record<string, unknown>> } = {};
+    try {
+      cfg = JSON.parse(await fs.readFile(cfgPath, "utf8"));
+    } catch {
+      // File doesn't exist yet; we'll create it.
+    }
+    cfg.projects ??= {};
+    cfg.projects[projectDir] ??= {};
+    cfg.projects[projectDir].hasTrustDialogAccepted = true;
+    cfg.projects[projectDir].hasCompletedProjectOnboarding = true;
+    await fs.writeFile(cfgPath, JSON.stringify(cfg, null, 2), "utf8");
+  } catch (e) {
+    console.error(`[crew] preAcceptWorkspaceTrust failed for ${projectDir}: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+/**
  * Auto-confirm Claude's dev-channel prompt by polling the screen buffer
  * for the prompt marker, then sending CR. Fire-and-forget; bounded by a
  * 30s deadline. Replaces the prior fixed-3s setTimeout which raced
  * Claude's startup time (the typical case on cold caches: claude takes
  * >3s to render the prompt, the CR lands in a still-starting shell, and
  * the agent stays stuck on the prompt forever).
+ *
+ * Handles BOTH consecutive prompts that may appear (dev-channels + an
+ * occasional secondary confirm) by sending CR each time the marker is
+ * still in the buffer. preAcceptWorkspaceTrust above eliminates the
+ * trust-dialog as a separate concern; this remains the fallback.
  */
 async function autoConfirmDevChannel(screenName: string, label: string): Promise<void> {
   const marker = "Enter to confirm";
   const deadline = Date.now() + 30_000;
+  let confirmsSent = 0;
   while (Date.now() < deadline) {
     try {
       const buf = await screen.readOutput(screenName);
       if (buf.includes(marker)) {
         await screen.sendKeys(screenName, "\r");
-        return;
+        confirmsSent++;
+        // Give the prompt a tick to redraw; if a second prompt is next, loop.
+        await new Promise((r) => setTimeout(r, 400));
+        if (confirmsSent >= 2) return;
+        continue;
       }
+      if (confirmsSent > 0) return; // sent at least one and marker is gone
     } catch {
       // screen may be momentarily unavailable during startup; retry
     }
     await new Promise((r) => setTimeout(r, 250));
   }
-  console.warn(
-    `[crew] dev-channel auto-confirm timed out for ${label} ` +
-    `(marker '${marker}' not seen in 30s)`,
-  );
+  if (confirmsSent === 0) {
+    console.warn(
+      `[crew] dev-channel auto-confirm timed out for ${label} ` +
+      `(marker '${marker}' not seen in 30s)`,
+    );
+  }
 }
 
 export class Orchestrator {
@@ -196,6 +239,9 @@ export class Orchestrator {
 
     // Build launch command. Template variables expand from env + PROJECT_DIR.
     const projectDir = opts.projectDir ?? process.cwd();
+    // Pre-accept Claude Code's workspace-trust dialog so CC ephemerals start
+    // straight into their prompt instead of stalling on a confirmation.
+    await preAcceptWorkspaceTrust(projectDir);
     const templateVars = { ...opts.env, PROJECT_DIR: projectDir };
     let command = getLaunchCommand(runtime, templateVars);
     if (opts.prompt) {
@@ -396,6 +442,8 @@ export class Orchestrator {
         `Pass project_dir explicitly.`,
       );
     }
+    // Same workspace-trust pre-accept as launchAgent.
+    await preAcceptWorkspaceTrust(projectDir);
 
     const runtime = opts.runtime ?? tomb?.runtime ?? manifest?.runtime ?? "claude-code";
     if (runtime !== "claude-code") {


### PR DESCRIPTION
## Summary

Three small fixes so CC ephemerals start straight into their prompt instead of stalling on confirmation dialogs that `--permission-mode bypassPermissions` doesn't actually bypass.

## Background

When you spawn a CC ephemeral with `--permission-mode bypassPermissions` against a project dir Claude hasn't seen before, it still shows two prompts:

1. The **workspace-trust dialog** ("Do you trust this workspace?") — separate from the permission mode.
2. The **dev-channel warning** ("Enter to confirm loading non-standard plugin channels") — sometimes appears twice in succession.

Result: agents land in the dialog, never reach their prompt, and `agent_attach` shows the user a frozen screen.

## What's in this PR

`src/orchestrator.ts` only. 3 surgical changes.

### 1. `preAcceptWorkspaceTrust(projectDir)`

Pre-writes `projects[<cwd>].hasTrustDialogAccepted = true` (and `hasCompletedProjectOnboarding`) into `~/.claude.json` before spawning. Called from `launchAgent` and `resumeAgent`. Best-effort: errors are logged, the agent still spawns, user can accept manually as a fallback.

### 2. `autoConfirmDevChannel` sends up to 2 CRs

The dev-channel prompt sometimes immediately re-prompts (a secondary confirm). Send CR each time the marker is in the buffer, up to 2 times, 400ms apart. If `confirmsSent >= 1` and the marker is gone, exit. Timeout warning only fires if zero confirms were sent.

### 3. Trailing `\n` on `screen -x` attach

~~Append `\n` to the writeToSession attach command.~~ **Now obsolete.** PR #75 replaced that line with `attachScreen()`, which handles the newline internally for cmux. This PR no longer touches that site — kept here for commit-history context.

## Out of scope

Org-wide silencing of the dev-channel warning via `/Library/Application Support/ClaudeCode/managed-settings.json` (template available at `/tmp/managed-settings.json` on Brian's daily-driver) — that's an operator-side install, not a code change.

## Test plan

- [x] `bun test` — 99/99 pass
- [x] Hot-tested locally: agent_launch + agent_attach lands directly in the CC prompt, no manual Enters required
- [ ] Live-test against a project dir Claude has never seen (verifies `preAcceptWorkspaceTrust` path)

## Commit history note

This commit was originally written on 2026-05-18 against pre-PR-#75 orchestrator.ts. Rebased onto current main; the screen-attach `\n` hunk was dropped during rebase because PR #75's `attachScreen()` abstraction made it moot. Net diff: +53/-5 in orchestrator.ts.

🤖 Peace , B.Sweet