### PR TITLE
fix(reconcile): cross-check screen pid with kill(pid,0); guard attach on dead screens (v2.11.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -45,6 +45,7 @@ function makeTerminal(): TerminalBackend {
     deletePaneProfile: mock(() => {}),
     setProfile: mock(async () => {}),
     sendText: mock(async () => {}),
+    attachScreen: mock(async () => {}),
   } as unknown as TerminalBackend;
 }
 
@@ -497,6 +498,43 @@ describe("resumeAgent", () => {
     expect(cmd).not.toContain("--resume");
     expect(cmd).toContain("cd '/tmp/nb'");
     expect(cmd).toContain("AGENT_ID='never-booted'");
+  });
+});
+
+describe("attachAgent screen-liveness guard", () => {
+  // Regression: pre-fix, attachAgent silently 'succeeded' against a dead
+  // screen session. Operator sees a blank pane and a green API response.
+  // Loom hit this 2026-05-23 — see feedback-screen-zombie-listings.
+  test("throws when the agent's screen session is dead", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "ghost", AGENT_NAME: "Ghost" } });
+    orch.store.createTab("eng");
+    const pane = orch.store.createPane("oak", "eng");
+    orch.store.setPaneItermId(pane.name, "iterm-session-123");
+
+    screenState.isAliveResult = false; // screen is dead
+    try {
+      await expect(orch.attachAgent("ghost", "oak"))
+        .rejects.toThrow(/screen session 'wire-ghost' is dead/);
+    } finally {
+      screenState.isAliveResult = false;
+    }
+  });
+
+  test("attaches normally when the screen session is alive", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "alive-agent", AGENT_NAME: "AliveAgent" } });
+    orch.store.createTab("eng");
+    const pane = orch.store.createPane("oak", "eng");
+    orch.store.setPaneItermId(pane.name, "iterm-session-456");
+
+    screenState.isAliveResult = true;
+    try {
+      await orch.attachAgent("alive-agent", "oak");
+      // Liveness guard should pass; pane assignment lands on the row.
+      const row = orch.store.getAgent("alive-agent");
+      expect(row?.pane).toBe("oak");
+    } finally {
+      screenState.isAliveResult = false;
+    }
   });
 });
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -704,6 +704,18 @@ export class Orchestrator {
     const agent = this.store.getAgent(agentId);
     if (!agent) throw new Error(`agent '${agentId}' not found`);
 
+    // Verify the screen session is actually alive. attachAgent used to
+    // silently no-op (screen.detachSession is .nothrow(), and screen -r
+    // against a dead session fails only inside the pane), so the API would
+    // claim success while the operator stared at a blank pane. Loom hit this
+    // 2026-05-23 attaching heddle whose screen had died during 21h of idle.
+    if (!(await screen.isAlive(agent.screen_name))) {
+      throw new Error(
+        `agent '${agentId}' screen session '${agent.screen_name}' is dead. ` +
+        `Run reconcile to prune the stale row, then re-spawn the agent.`,
+      );
+    }
+
     // Auto-swap to a themed pane if needed
     const resolvedPane = await this.ensureThemedPane(paneName);
 

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -62,7 +62,21 @@ export async function reconcile(
 
     knownScreenNames.add(agent.screen_name);
     const session = sessionByName.get(agent.screen_name);
+    // Two-step liveness check. `screen -ls` lists zombie sessions briefly
+    // after process death, until screen GCs the socket. Without the kill(pid,
+    // 0) cross-check, the reconciler touches a dead agent as alive and the
+    // stale row poisons downstream operations (agent_list, attach). Loom hit
+    // this 2026-05-23 with heddle after a 21h-idle screen death.
+    let isLive = false;
     if (session) {
+      try {
+        process.kill(session.pid, 0);
+        isLive = true;
+      } catch {
+        isLive = false;
+      }
+    }
+    if (isLive && session) {
       store.updateAgentPid(agent.id, session.pid);
       store.touchAgent(agent.id);
       alive.push(agent.id);

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -124,9 +124,22 @@ export async function isAttached(name: string): Promise<boolean> {
 
 /**
  * Check if a screen session is alive.
+ *
+ * Belt-and-suspenders: `screen -ls` will list a zombie session briefly after
+ * its process dies, until screen GCs the socket. Cross-check the pid with
+ * `kill(pid, 0)` so callers (attach, reconciler) don't trust a stale listing
+ * and end up operating on a dead session. Loom hit this 2026-05-23 — see
+ * `feedback-screen-zombie-listings` for the incident.
  */
 export async function isAlive(name: string): Promise<boolean> {
-  return (await getSessionPid(name)) !== null;
+  const pid = await getSessionPid(name);
+  if (pid === null) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Three crew paths trusted `screen -ls` as the sole liveness signal and operated on dead screen sessions. The fix is a single canonical liveness check (`kill(pid, 0)` on top of the screen-ls pid) applied in all three places.

- `screen.isAlive` now cross-checks the pid with `process.kill(pid, 0)` after looking it up via `screen -ls`. Same return type, tighter semantics.
- `reconciler` agent loop does the same kill-check inline (so the reconciler's intent is readable without jumping to screen.ts).
- `orchestrator.attachAgent` calls `screen.isAlive` up front and throws a clear error if the session is dead — previously it silently no-op'd because `detachSession` is `.nothrow()` and `terminal.attachScreen` surfaces errors only inside the pane.

## Why

`screen -ls` lists zombie sessions for a brief window after the underlying process dies, until screen GCs the socket. That window was long enough to poison three different operator-facing operations.

Loom hit all three on 2026-05-23 attaching heddle whose screen had died during ~21h of idle:

- `crew.agent_list` returned heddle with the dead pid and last_seen 21h ago
- `crew.reconcile` reported heddle as "attached: pane:oak"
- `agent_attach id=heddle pane=oak` claimed success — pane stayed blank
- Manual `screen -ls` (run later) showed only the live kx sidecar

Loom had to manually `agent_stop heddle` to force-clear the registry, then re-spawn. The session-state on Brian's box now correctly tracks this incident as the impetus.

## Test plan

- [x] `bun test` — 101/101 pass (vs. 99 before; +2 attach-guard tests in `orchestrator.test.ts`)
- [x] Existing `reconcile cross-machine safety > skips agents on peer machines` still passes (kill-check only runs for local rows)
- [x] New: `attachAgent screen-liveness guard > throws when the agent's screen session is dead`
- [x] New: `attachAgent screen-liveness guard > attaches normally when the screen session is alive`
- [ ] (Manual, post-merge) Repro loom's scenario: spawn an agent, kill the underlying process behind its screen, run reconcile → expect the dead row pruned

## Risk

Low. The kill-check is a strictly tighter version of the existing check — anything that would have been reported as dead before is still dead now; anything that was a zombie now correctly resolves as dead. The attach guard is the only behavior change visible to callers: attempts to attach a dead-screen agent now throw with guidance instead of silently no-op'ing. Callers were already operating on the assumption that attach succeeds when reported, so an explicit error is strictly more informative.

🤖 Generated by 🧰 SweetFondant (Brian-side fondant clone)