### PR TITLE
feat(crew): tab_active — resolve the operator's focused tab to a crew tab (v2.12.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -247,6 +247,20 @@ export class CmuxBackend implements TerminalBackend {
     return info.focused?.surface_ref ?? info.focused?.surfaceRef;
   }
 
+  async currentTabId(): Promise<string | null> {
+    // cmux 'identify' returns focused.workspace_ref — the workspace the
+    // operator is currently viewing. Crew tabs map 1:1 to cmux workspaces
+    // and store the workspace ref in tabs.iterm_session_id (legacy column
+    // name; semantics are backend-agnostic).
+    try {
+      const info = await cmuxJson("identify");
+      const ws = info.focused?.workspace_ref ?? info.focused?.workspaceRef;
+      return typeof ws === "string" ? ws : null;
+    } catch {
+      return null;
+    }
+  }
+
   async sessionIdForTty(ttyName: string): Promise<string | null> {
     try {
       // Use tree --json to find all surfaces and match by TTY

--- a/src/iterm-backend.ts
+++ b/src/iterm-backend.ts
@@ -12,6 +12,18 @@ export class ItermBackend implements TerminalBackend {
     return iterm.currentSessionId();
   }
 
+  async currentTabId(): Promise<string | null> {
+    // iTerm2 tabs are not first-class — the closest stable identifier for
+    // "the tab the operator is looking at" is the id of the first session
+    // in the current tab, which matches what we store in
+    // tabs.iterm_session_id at crew tab creation time.
+    try {
+      return await iterm.currentTabFirstSessionId();
+    } catch {
+      return null;
+    }
+  }
+
   sessionIdForTty(ttyName: string): Promise<string | null> {
     return iterm.sessionIdForTty(ttyName);
   }

--- a/src/iterm.ts
+++ b/src/iterm.ts
@@ -40,6 +40,23 @@ export async function currentSessionId(): Promise<string> {
 }
 
 /**
+ * Get the iTerm2 session ID of the FIRST session of the current tab. This is
+ * the stable identifier we use to match crew-tracked tabs (tabs.iterm_session_id
+ * is stamped from the initial pane's session id at create-tab time). The
+ * current session may be any pane in the tab; the first session anchors the
+ * tab identity.
+ */
+export async function currentTabFirstSessionId(): Promise<string> {
+  return osascript(`
+    tell application "iTerm2"
+      tell current tab of current window
+        return id of first session
+      end tell
+    end tell
+  `);
+}
+
+/**
  * Get the iTerm2 session ID for the session owning a specific TTY.
  * More reliable than ITERM_SESSION_ID env var which can go stale.
  */

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -447,6 +447,11 @@ export async function startServer(): Promise<void> {
       inputSchema: { type: "object" as const, properties: {} },
     },
     {
+      name: "tab_active",
+      description: "Return the crew-tracked tab the operator is currently viewing, or null if the focused tab is not crew-tracked or can't be determined. Use this before spawning a new pane to land it where the operator's eyes are, instead of creating a fresh tab they have to switch to.",
+      inputSchema: { type: "object" as const, properties: {} },
+    },
+    {
       name: "tab_destroy",
       description: "Destroy a tab and all its panes. Agents in those panes are detached (keep running headless). NEVER destroy a tab containing a pane you are sitting in.",
       inputSchema: {
@@ -764,6 +769,9 @@ export async function startServer(): Promise<void> {
           break;
         case "tab_list":
           result = orchestrator.listTabs();
+          break;
+        case "tab_active":
+          result = { tab: await orchestrator.activeTab() };
           break;
         case "tab_destroy":
           orchestrator.deleteTab(a.name as string);

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -25,10 +25,15 @@ mock.module("./screen", () => ({
 
 const { Orchestrator } = await import("./orchestrator");
 
+// Mutable state for the terminal mock so tests can flip what currentTabId
+// reports without re-mocking the entire backend per case.
+const terminalState = { currentTabId: null as string | null };
+
 function makeTerminal(): TerminalBackend {
   return {
     name: "test",
     currentSessionId: mock(async () => ""),
+    currentTabId: mock(async () => terminalState.currentTabId),
     sessionIdForTty: mock(async () => null),
     splitPane: mock(async () => ""),
     splitSession: mock(async () => ""),
@@ -497,6 +502,38 @@ describe("resumeAgent", () => {
     expect(cmd).not.toContain("--resume");
     expect(cmd).toContain("cd '/tmp/nb'");
     expect(cmd).toContain("AGENT_ID='never-booted'");
+  });
+});
+
+describe("activeTab introspection", () => {
+  test("returns the crew tab whose iterm_session_id matches the focused tab", async () => {
+    orch.store.createTab("eng", undefined, "workspace:3");
+    orch.store.createTab("ops", undefined, "workspace:4");
+    terminalState.currentTabId = "workspace:3";
+    try {
+      const active = await orch.activeTab();
+      expect(active?.name).toBe("eng");
+    } finally {
+      terminalState.currentTabId = null;
+    }
+  });
+
+  test("returns null when the focused tab is not crew-tracked", async () => {
+    orch.store.createTab("eng", undefined, "workspace:3");
+    terminalState.currentTabId = "workspace:99"; // some manually-opened cmux ws
+    try {
+      const active = await orch.activeTab();
+      expect(active).toBeNull();
+    } finally {
+      terminalState.currentTabId = null;
+    }
+  });
+
+  test("returns null when the backend can't resolve a focused tab", async () => {
+    orch.store.createTab("eng", undefined, "workspace:3");
+    terminalState.currentTabId = null; // backend returned null
+    const active = await orch.activeTab();
+    expect(active).toBeNull();
   });
 });
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1071,6 +1071,30 @@ export class Orchestrator {
     return this.store.listTabs();
   }
 
+  /**
+   * Return the crew-tracked tab the operator is currently viewing, or null
+   * if no tracked tab matches the focused workspace/window. Used by
+   * placement-aware spawn flows: bridge.spawn can call this to land a new
+   * pane in the operator's current tab instead of creating an orphan tab
+   * they have to switch to manually.
+   *
+   * Returns null in three cases: (a) the terminal backend can't resolve a
+   * focused tab (no window in focus, AppleScript denied, etc.); (b) the
+   * focused tab is not crew-tracked (e.g., a shell tab the operator opened
+   * manually); (c) the backend's currentTabId returned a value that doesn't
+   * match any tab.iterm_session_id. Callers treating null as "place into a
+   * fresh tab" preserve the pre-fix behavior.
+   *
+   * See [[draft-crew-tools-papercuts-from-loom]] §2 for the surfacing
+   * incident (loom 2026-05-23 spawning heddle into a new tab while Brian
+   * watched a different tab).
+   */
+  async activeTab(): Promise<Tab | null> {
+    const tabId = await this.terminal.currentTabId();
+    if (!tabId) return null;
+    return this.store.listTabs().find((t) => t.iterm_session_id === tabId) ?? null;
+  }
+
   deleteTab(name: string): void {
     this.store.deleteTab(name);
   }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -32,6 +32,20 @@ export interface TerminalBackend {
   /** Get the session/surface ID of the current (focused) terminal. */
   currentSessionId(): Promise<string>;
 
+  /**
+   * Get the tab/workspace ID of the focused tab — i.e. where the operator's
+   * eyes are. Matches the `iterm_session_id` column in `crews.db.tabs` for
+   * crew-tracked tabs.
+   *
+   * Returns null if the active tab can't be resolved (no focused window,
+   * AppleScript denied, cmux daemon unreachable, etc.). Callers should
+   * treat null as "unknown — fall back to default placement."
+   *
+   * cmux: returns the focused workspace's ref (e.g. "workspace:3").
+   * iTerm2: returns the id of the first session in the current tab.
+   */
+  currentTabId(): Promise<string | null>;
+
   /** Resolve a TTY device path to a session/surface ID. */
   sessionIdForTty(ttyName: string): Promise<string | null>;
 


### PR DESCRIPTION
## Summary

Adds the primitive crew needed for placement-aware spawning: a single call to ask the terminal backend \"which tab is the operator looking at?\" and resolve that to a crew-tracked Tab.

- `TerminalBackend.currentTabId(): Promise<string | null>` — new interface method
- `CmuxBackend`: returns `focused.workspace_ref` from `cmux identify`
- `ItermBackend`: returns the id of the first session of the current tab (matches what we stamp into `tabs.iterm_session_id` at tab creation time)
- `Orchestrator.activeTab(): Promise<Tab | null>` — resolves backend id → crew Tab
- MCP tool `tab_active` — exposes it to callers

## Why

When loom spawned heddle 2026-05-23, `tab_list` returned `[]`. Correct interpretation: \"no crew-tracked tabs.\" Misleading-by-omission interpretation: \"no tabs in iTerm/cmux.\" Loom (reasonably) created a fresh `tankloop` tab and attached heddle there. Brian was looking at a different tab and had to switch manually to see the new agent.

The fix is a primitive query that returns the focused tab or null. Spawning code (bridge.spawn, agent_launch + agent_attach flows) can call this before creating a tab and reuse the focused one when crew already tracks it.

See [[draft-crew-tools-papercuts-from-loom]] §2 for the original report. #3 (heddle's `spawn.sh --model` default) is being routed to heddle separately.

## Out of scope

- `bridge.spawn` `tab: 'current'` placement mode — that's a small follow-up in bridge-claude-code that calls `tab_active` and falls back to a fresh tab on null. Splitting because crew owns the primitive and bridge owns the sugar.
- Marking `is_active` per row in `tab_list` output — could layer on later; for now `tab_active` is the focused query.

## Test plan

- [x] `bun test` — 102/102 pass (added 3 cases: match / non-tracked / backend-null)
- [x] cmux path manually exercised on Brian's box: `cmux identify | jq .focused.workspace_ref` returns the visible workspace; `tab_active` then matches it to the right crew tab when one exists
- [ ] (Manual, post-merge) Drive bridge.spawn with `tab_active`-aware placement on a real spawn

## Risk

Low. Pure addition — new interface method (both backends implement, default to null on resolution failure), new orchestrator method, new MCP tool. No existing call paths changed.

🤖 Generated by 🧰 SweetFondant