### PR TITLE
crew-tools v2.12.0 — capability split + reconcile-liveness fix + tab_active

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.13.0",
+  "version": "2.12.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.11.0",
+  "version": "2.13.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/capabilities/notifications.contract.ts
+++ b/src/capabilities/notifications.contract.ts
@@ -1,0 +1,50 @@
+/**
+ * Notifications contract — shared assertions every backend's Notifications
+ * implementation must pass. Backend-specific test files (cmux/iterm) call
+ * `runNotificationsContract(impl)` from their suites; the impl can be the
+ * real backend's capability or a mocked one wired against the same
+ * interface.
+ *
+ * The contract checks SEMANTIC obligations, not transport details:
+ *  - notify() resolves without throwing when given valid inputs
+ *  - flash() resolves without throwing when given valid inputs
+ *  - notify() tolerates an absent `body`
+ *  - both methods accept the same `sessionId` shape the rest of the
+ *    backend accepts (we don't make assumptions about format)
+ *
+ * Transport assertions (correct OSC bytes for iTerm, correct CLI args for
+ * cmux) live in each backend's own unit tests, not here.
+ */
+
+import { describe, test, expect } from "bun:test";
+import type { NotificationsCapability } from "./notifications.js";
+
+export function runNotificationsContract(
+  label: string,
+  factory: () => NotificationsCapability,
+  opts: { exampleSessionId: string },
+): void {
+  describe(`NotificationsCapability contract — ${label}`, () => {
+    test("notify resolves with title only", async () => {
+      const impl = factory();
+      await expect(impl.notify(opts.exampleSessionId, "test title")).resolves.toBeUndefined();
+    });
+
+    test("notify resolves with title and body", async () => {
+      const impl = factory();
+      await expect(
+        impl.notify(opts.exampleSessionId, "test title", "test body"),
+      ).resolves.toBeUndefined();
+    });
+
+    test("flash resolves", async () => {
+      const impl = factory();
+      await expect(impl.flash(opts.exampleSessionId)).resolves.toBeUndefined();
+    });
+
+    test("notify with empty body still resolves", async () => {
+      const impl = factory();
+      await expect(impl.notify(opts.exampleSessionId, "title", "")).resolves.toBeUndefined();
+    });
+  });
+}

--- a/src/capabilities/notifications.ts
+++ b/src/capabilities/notifications.ts
@@ -1,0 +1,27 @@
+/**
+ * Notifications capability — attention-getting operations that surface
+ * events to the operator outside the pane content itself.
+ *
+ * Backends that register this capability MUST have a real native
+ * implementation. cmux fires native OS notifications and tab-ring flashes;
+ * iTerm2 uses OSC 9 (macOS notification banner) for `notify` and OSC 1337
+ * RequestAttention (dock bounce) for `flash`. A backend that can only
+ * approximate via `setBadge` should NOT register this capability — leave
+ * it absent and let the caller decide whether to fall back.
+ */
+export interface NotificationsCapability {
+  /**
+   * Send a rich notification tied to a session. The operator typically sees
+   * this as an OS-level banner (cmux: native; iTerm2: OSC 9 → macOS).
+   *
+   * Returns void; never throws on transient backend errors — notifications
+   * are decorative. Hard failures (auth, plugin gone) should bubble up.
+   */
+  notify(sessionId: string, title: string, body?: string): Promise<void>;
+
+  /**
+   * Flash / request attention on the tab containing this session. cmux
+   * triggers the tab notification ring; iTerm2 bounces the dock icon.
+   */
+  flash(sessionId: string): Promise<void>;
+}

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Capability registry — typed map of optional terminal features.
+ *
+ * Each capability is an interface in this folder (or a sibling folder like
+ * `cmux-only/`) describing a named cluster of operations that some backends
+ * implement and others don't. Backends register the capabilities they
+ * implement; callers query via `terminal.capability("name")` and get back
+ * either an implementation or `null`.
+ *
+ * Principle: **absence beats degraded behavior when the fallback changes
+ * user-visible state.** A capability advertises the semantic operation, not
+ * a clever approximation. Callers that want a fallback write
+ * `capability("X")?.op(...) ?? core.fallbackOp(...)` so the product decision
+ * is visible at the call site, not hidden in the backend.
+ *
+ * See `docs` or [[plan-terminal-capabilities-split]] (Fondant vault) for the
+ * design rationale and the cmux/iterm migration plan.
+ */
+
+import type { NotificationsCapability } from "./notifications.js";
+
+/**
+ * The canonical registry of capability names → implementation types.
+ *
+ * Adding a new capability:
+ *  1. Define its interface in `src/capabilities/<name>.ts`.
+ *  2. Add the mapping here: `"<name>": <Name>Capability`.
+ *  3. Implement it in backends that have native support
+ *     (`src/cmux/capabilities/<name>.ts`, `src/iterm/capabilities/<name>.ts`).
+ *  4. Register the implementation via the backend's `registerCapabilities()`.
+ */
+export interface CapabilityMap {
+  notifications: NotificationsCapability;
+}
+
+/**
+ * Internal capability registry used by backend implementations to map names
+ * to instances. Not exported — backends compose this via `registerCapabilities`.
+ */
+export type CapabilityRegistry = {
+  [K in keyof CapabilityMap]?: CapabilityMap[K];
+};

--- a/src/cmux-capabilities/notifications.integration.test.ts
+++ b/src/cmux-capabilities/notifications.integration.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Integration test for cmux Notifications.
+ *
+ * Runs against the live CmuxBackend (which means a real cmux daemon and a
+ * real surface). Gated on cmux CLI being on PATH; otherwise skipped. Brian
+ * runs this on his cmux-equipped box; CI does not (no daemon).
+ *
+ * To run: `bun test src/cmux-capabilities/notifications.integration.test.ts`
+ * To skip: just don't have cmux on PATH, or set CREW_SKIP_CMUX_INTEGRATION=1.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { existsSync } from "fs";
+
+const CMUX_BIN =
+  process.env.CMUX_BUNDLED_CLI_PATH ||
+  "/Applications/agiterra-overlay.app/Contents/Resources/bin/cmux";
+
+const cmuxAvailable =
+  existsSync(CMUX_BIN) && !process.env.CREW_SKIP_CMUX_INTEGRATION;
+
+describe.if(cmuxAvailable)("cmux Notifications — live integration", () => {
+  test("notify against the focused surface does not throw", async () => {
+    const { CmuxBackend } = await import("../cmux");
+    const backend = new CmuxBackend();
+    const notif = backend.capability("notifications");
+    expect(notif).not.toBeNull();
+    const sid = await backend.currentSessionId();
+    // Real notification fires; integration test just asserts the call path
+    // doesn't throw. Visual confirmation is on the operator.
+    await expect(
+      notif!.notify(sid, "crew-tools integration", "notification test"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("flash against the focused surface does not throw", async () => {
+    const { CmuxBackend } = await import("../cmux");
+    const backend = new CmuxBackend();
+    const notif = backend.capability("notifications");
+    expect(notif).not.toBeNull();
+    const sid = await backend.currentSessionId();
+    await expect(notif!.flash(sid)).resolves.toBeUndefined();
+  });
+});
+
+describe.if(!cmuxAvailable)("cmux Notifications — live integration (SKIPPED)", () => {
+  test("cmux CLI not found at expected path; skipping integration suite", () => {
+    expect(cmuxAvailable).toBe(false);
+  });
+});

--- a/src/cmux-capabilities/notifications.integration.test.ts
+++ b/src/cmux-capabilities/notifications.integration.test.ts
@@ -12,12 +12,19 @@
 import { describe, test, expect } from "bun:test";
 import { existsSync } from "fs";
 
-const CMUX_BIN =
-  process.env.CMUX_BUNDLED_CLI_PATH ||
-  "/Applications/agiterra-overlay.app/Contents/Resources/bin/cmux";
+// Probe a few well-known cmux CLI locations on macOS. cmux's bundle id varies
+// across operator setups (agiterra.app, agiterra-overlay.app, cmux.app); the
+// CLI is always at <bundle>/Contents/Resources/bin/cmux. Falls back to PATH.
+const CANDIDATE_CMUX_BINS = [
+  process.env.CMUX_BUNDLED_CLI_PATH,
+  "/Applications/agiterra.app/Contents/Resources/bin/cmux",
+  "/Applications/agiterra-overlay.app/Contents/Resources/bin/cmux",
+  "/Applications/cmux.app/Contents/Resources/bin/cmux",
+].filter((p): p is string => Boolean(p));
 
 const cmuxAvailable =
-  existsSync(CMUX_BIN) && !process.env.CREW_SKIP_CMUX_INTEGRATION;
+  CANDIDATE_CMUX_BINS.some((p) => existsSync(p)) &&
+  !process.env.CREW_SKIP_CMUX_INTEGRATION;
 
 describe.if(cmuxAvailable)("cmux Notifications — live integration", () => {
   test("notify against the focused surface does not throw", async () => {

--- a/src/cmux-capabilities/notifications.test.ts
+++ b/src/cmux-capabilities/notifications.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "bun:test";
+import { CmuxNotifications, type CmuxCli, type SurfaceArgsResolver } from "./notifications";
+import { runNotificationsContract } from "../capabilities/notifications.contract";
+
+function makeMocks(opts: { cliResult?: string; cliThrows?: Error } = {}) {
+  const calls: string[][] = [];
+  const cli: CmuxCli = async (...args) => {
+    calls.push(args);
+    if (opts.cliThrows) throw opts.cliThrows;
+    return opts.cliResult ?? "OK";
+  };
+  const surfaceArgs: SurfaceArgsResolver = async (sid) => ["--surface", sid];
+  return { cli, surfaceArgs, calls };
+}
+
+describe("CmuxNotifications transport", () => {
+  test("notify invokes cmux 'notify' with --title and surface args", async () => {
+    const { cli, surfaceArgs, calls } = makeMocks();
+    const impl = new CmuxNotifications(cli, surfaceArgs);
+    await impl.notify("surface:7", "hello");
+    expect(calls).toEqual([["notify", "--title", "hello", "--surface", "surface:7"]]);
+  });
+
+  test("notify appends --body when present", async () => {
+    const { cli, surfaceArgs, calls } = makeMocks();
+    const impl = new CmuxNotifications(cli, surfaceArgs);
+    await impl.notify("surface:7", "hello", "world");
+    expect(calls[0]).toContain("--body");
+    expect(calls[0]).toContain("world");
+  });
+
+  test("flash invokes cmux 'trigger-flash' with surface args", async () => {
+    const { cli, surfaceArgs, calls } = makeMocks();
+    const impl = new CmuxNotifications(cli, surfaceArgs);
+    await impl.flash("surface:7");
+    expect(calls).toEqual([["trigger-flash", "--surface", "surface:7"]]);
+  });
+
+  test("notify swallows CLI errors (decorative)", async () => {
+    const { cli, surfaceArgs } = makeMocks({ cliThrows: new Error("cmux not running") });
+    const impl = new CmuxNotifications(cli, surfaceArgs);
+    await expect(impl.notify("surface:7", "hello")).resolves.toBeUndefined();
+  });
+
+  test("flash swallows CLI errors (decorative)", async () => {
+    const { cli, surfaceArgs } = makeMocks({ cliThrows: new Error("cmux not running") });
+    const impl = new CmuxNotifications(cli, surfaceArgs);
+    await expect(impl.flash("surface:7")).resolves.toBeUndefined();
+  });
+});
+
+runNotificationsContract(
+  "cmux",
+  () => {
+    const { cli, surfaceArgs } = makeMocks();
+    return new CmuxNotifications(cli, surfaceArgs);
+  },
+  { exampleSessionId: "surface:1" },
+);

--- a/src/cmux-capabilities/notifications.ts
+++ b/src/cmux-capabilities/notifications.ts
@@ -1,0 +1,40 @@
+/**
+ * cmux Notifications capability — wraps cmux's native `notify` and
+ * `trigger-flash` CLI commands.
+ *
+ * Constructor-injected with the cmux CLI invoker and surface-args resolver
+ * from the backend so the capability is unit-testable in isolation: mock the
+ * `cli` function, run notify(), assert the args.
+ */
+
+import type { NotificationsCapability } from "../capabilities/notifications.js";
+
+export type CmuxCli = (...args: string[]) => Promise<string>;
+export type SurfaceArgsResolver = (sessionId: string) => Promise<string[]>;
+
+export class CmuxNotifications implements NotificationsCapability {
+  constructor(
+    private readonly cli: CmuxCli,
+    private readonly surfaceArgs: SurfaceArgsResolver,
+  ) {}
+
+  async notify(sessionId: string, title: string, body?: string): Promise<void> {
+    try {
+      const surfaceArgs = await this.surfaceArgs(sessionId);
+      const args = ["notify", "--title", title, ...surfaceArgs];
+      if (body) args.push("--body", body);
+      await this.cli(...args);
+    } catch {
+      // Non-fatal — notifications are decorative.
+    }
+  }
+
+  async flash(sessionId: string): Promise<void> {
+    try {
+      const args = await this.surfaceArgs(sessionId);
+      await this.cli("trigger-flash", ...args);
+    } catch {
+      // Non-fatal — flash is decorative.
+    }
+  }
+}

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -14,6 +14,11 @@
 
 import { $ } from "bun";
 import type { TerminalBackend, PaneProfile } from "./terminal.js";
+import type { CapabilityMap, CapabilityRegistry } from "./capabilities/types.js";
+import { CmuxNotifications } from "./cmux-capabilities/notifications.js";
+
+// Capability registration deferred to constructor (needs class-private
+// `surfaceArgs` binding). Field declared, populated in constructor.
 
 /**
  * Run a cmux CLI command and return trimmed stdout.
@@ -80,6 +85,18 @@ export class CmuxBackend implements TerminalBackend {
    */
   private profileStore = new Map<string, PaneProfile>();
   private profileSeq = 0;
+
+  private readonly _capabilities: CapabilityRegistry;
+
+  constructor() {
+    this._capabilities = {
+      notifications: new CmuxNotifications(cmux, (sid) => this.surfaceArgs(sid)),
+    };
+  }
+
+  capability<K extends keyof CapabilityMap>(name: K): CapabilityMap[K] | null {
+    return (this._capabilities[name] as CapabilityMap[K] | undefined) ?? null;
+  }
 
   /**
    * Resolve a caller-supplied surface identifier (short ref OR UUID) to the
@@ -437,24 +454,20 @@ export class CmuxBackend implements TerminalBackend {
     }
   }
 
+  /**
+   * @deprecated Phase 1 shim. Use `capability("notifications")?.flash(sessionId)`.
+   * Removed in v3.0.0.
+   */
   async flashSession(sessionId: string): Promise<void> {
-    try {
-      const args = await this.surfaceArgs(sessionId);
-      await cmux("trigger-flash", ...args);
-    } catch {
-      // Non-fatal
-    }
+    await this.capability("notifications")?.flash(sessionId);
   }
 
+  /**
+   * @deprecated Phase 1 shim. Use `capability("notifications")?.notify(...)`.
+   * Removed in v3.0.0.
+   */
   async notifySession(sessionId: string, title: string, body?: string): Promise<void> {
-    try {
-      const surfaceArgs = await this.surfaceArgs(sessionId);
-      const args = ["notify", "--title", title, ...surfaceArgs];
-      if (body) args.push("--body", body);
-      await cmux(...args);
-    } catch {
-      // Non-fatal
-    }
+    await this.capability("notifications")?.notify(sessionId, title, body);
   }
 
   async renameWorkspace(sessionId: string, name: string): Promise<void> {

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -264,6 +264,20 @@ export class CmuxBackend implements TerminalBackend {
     return info.focused?.surface_ref ?? info.focused?.surfaceRef;
   }
 
+  async currentTabId(): Promise<string | null> {
+    // cmux 'identify' returns focused.workspace_ref — the workspace the
+    // operator is currently viewing. Crew tabs map 1:1 to cmux workspaces
+    // and store the workspace ref in tabs.iterm_session_id (legacy column
+    // name; semantics are backend-agnostic).
+    try {
+      const info = await cmuxJson("identify");
+      const ws = info.focused?.workspace_ref ?? info.focused?.workspaceRef;
+      return typeof ws === "string" ? ws : null;
+    } catch {
+      return null;
+    }
+  }
+
   async sessionIdForTty(ttyName: string): Promise<string | null> {
     try {
       // Use tree --json to find all surfaces and match by TTY

--- a/src/iterm-backend.ts
+++ b/src/iterm-backend.ts
@@ -22,6 +22,18 @@ export class ItermBackend implements TerminalBackend {
     return iterm.currentSessionId();
   }
 
+  async currentTabId(): Promise<string | null> {
+    // iTerm2 tabs are not first-class — the closest stable identifier for
+    // "the tab the operator is looking at" is the id of the first session
+    // in the current tab, which matches what we store in
+    // tabs.iterm_session_id at crew tab creation time.
+    try {
+      return await iterm.currentTabFirstSessionId();
+    } catch {
+      return null;
+    }
+  }
+
   sessionIdForTty(ttyName: string): Promise<string | null> {
     return iterm.sessionIdForTty(ttyName);
   }

--- a/src/iterm-backend.ts
+++ b/src/iterm-backend.ts
@@ -3,10 +3,20 @@
  */
 
 import type { TerminalBackend, PaneProfile } from "./terminal.js";
+import type { CapabilityMap, CapabilityRegistry } from "./capabilities/types.js";
 import * as iterm from "./iterm.js";
+import { ItermNotifications } from "./iterm-capabilities/notifications.js";
 
 export class ItermBackend implements TerminalBackend {
   readonly name = "iterm" as const;
+
+  private readonly _capabilities: CapabilityRegistry = {
+    notifications: new ItermNotifications(iterm.writeEscapeToSession),
+  };
+
+  capability<K extends keyof CapabilityMap>(name: K): CapabilityMap[K] | null {
+    return (this._capabilities[name] as CapabilityMap[K] | undefined) ?? null;
+  }
 
   currentSessionId(): Promise<string> {
     return iterm.currentSessionId();
@@ -98,15 +108,20 @@ export class ItermBackend implements TerminalBackend {
     return iterm.splitSessionWithProfile(sessionId, direction, profileName);
   }
 
+  /**
+   * @deprecated Phase 1 shim. Use `capability("notifications")?.flash(sessionId)`.
+   * Removed in v3.0.0.
+   */
   async flashSession(sessionId: string): Promise<void> {
-    // Bounce the dock icon via OSC 1337 RequestAttention
-    await iterm.writeEscapeToSession(sessionId, "\x1b]1337;RequestAttention=fireworks\x07");
+    await this.capability("notifications")?.flash(sessionId);
   }
 
+  /**
+   * @deprecated Phase 1 shim. Use `capability("notifications")?.notify(...)`.
+   * Removed in v3.0.0.
+   */
   async notifySession(sessionId: string, title: string, body?: string): Promise<void> {
-    // macOS notification banner via OSC 9
-    const msg = body ? `${title}: ${body}` : title;
-    await iterm.writeEscapeToSession(sessionId, `\x1b]9;${msg}\x07`);
+    await this.capability("notifications")?.notify(sessionId, title, body);
   }
 
   async renameWorkspace(_sessionId: string, _name: string): Promise<void> {

--- a/src/iterm-capabilities/notifications.integration.test.ts
+++ b/src/iterm-capabilities/notifications.integration.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Integration test for iTerm2 Notifications.
+ *
+ * Runs against the live ItermBackend (which means a real iTerm2 process and
+ * a real TTY). Gated on running inside iTerm2 (ITERM_SESSION_ID env);
+ * otherwise skipped. Tim runs this on his iTerm-equipped box; CI does not.
+ *
+ * To run: `bun test src/iterm-capabilities/notifications.integration.test.ts`
+ * (must be invoked from within an iTerm2 session)
+ * To skip: run from any other terminal, or set CREW_SKIP_ITERM_INTEGRATION=1.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+const itermAvailable =
+  !!process.env.ITERM_SESSION_ID && !process.env.CREW_SKIP_ITERM_INTEGRATION;
+
+describe.if(itermAvailable)("iTerm2 Notifications — live integration", () => {
+  test("notify against the current session does not throw", async () => {
+    const { ItermBackend } = await import("../iterm-backend");
+    const backend = new ItermBackend();
+    const notif = backend.capability("notifications");
+    expect(notif).not.toBeNull();
+    const sid = await backend.currentSessionId();
+    // OSC 9 banner fires; integration test just asserts the call path
+    // doesn't throw. Visual confirmation is on the operator.
+    await expect(
+      notif!.notify(sid, "crew-tools integration", "notification test"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("flash against the current session does not throw", async () => {
+    const { ItermBackend } = await import("../iterm-backend");
+    const backend = new ItermBackend();
+    const notif = backend.capability("notifications");
+    expect(notif).not.toBeNull();
+    const sid = await backend.currentSessionId();
+    await expect(notif!.flash(sid)).resolves.toBeUndefined();
+  });
+});
+
+describe.if(!itermAvailable)("iTerm2 Notifications — live integration (SKIPPED)", () => {
+  test("ITERM_SESSION_ID not set; skipping integration suite", () => {
+    expect(itermAvailable).toBe(false);
+  });
+});

--- a/src/iterm-capabilities/notifications.test.ts
+++ b/src/iterm-capabilities/notifications.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from "bun:test";
+import { ItermNotifications, type EscapeWriter } from "./notifications";
+import { runNotificationsContract } from "../capabilities/notifications.contract";
+
+function makeMocks(opts: { throws?: Error } = {}) {
+  const calls: Array<{ sessionId: string; escape: string }> = [];
+  const writeEscape: EscapeWriter = async (sessionId, escape) => {
+    calls.push({ sessionId, escape });
+    if (opts.throws) throw opts.throws;
+  };
+  return { writeEscape, calls };
+}
+
+describe("ItermNotifications transport", () => {
+  test("notify writes OSC 9 with title only", async () => {
+    const { writeEscape, calls } = makeMocks();
+    const impl = new ItermNotifications(writeEscape);
+    await impl.notify("iterm:session:abc", "hello");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sessionId).toBe("iterm:session:abc");
+    // OSC 9 ; <text> BEL
+    expect(calls[0].escape).toBe("\x1b]9;hello\x07");
+  });
+
+  test("notify writes OSC 9 with combined title:body", async () => {
+    const { writeEscape, calls } = makeMocks();
+    const impl = new ItermNotifications(writeEscape);
+    await impl.notify("iterm:session:abc", "hello", "world");
+    expect(calls[0].escape).toBe("\x1b]9;hello: world\x07");
+  });
+
+  test("flash writes OSC 1337 RequestAttention=fireworks", async () => {
+    const { writeEscape, calls } = makeMocks();
+    const impl = new ItermNotifications(writeEscape);
+    await impl.flash("iterm:session:abc");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].escape).toBe("\x1b]1337;RequestAttention=fireworks\x07");
+  });
+
+  test("empty body falls back to title-only encoding (no trailing colon)", async () => {
+    const { writeEscape, calls } = makeMocks();
+    const impl = new ItermNotifications(writeEscape);
+    await impl.notify("iterm:session:abc", "title", "");
+    // Falsy body skips the title:body join
+    expect(calls[0].escape).toBe("\x1b]9;title\x07");
+  });
+});
+
+runNotificationsContract(
+  "iterm",
+  () => {
+    const { writeEscape } = makeMocks();
+    return new ItermNotifications(writeEscape);
+  },
+  { exampleSessionId: "iterm:session:abc" },
+);

--- a/src/iterm-capabilities/notifications.ts
+++ b/src/iterm-capabilities/notifications.ts
@@ -1,0 +1,29 @@
+/**
+ * iTerm2 Notifications capability — wraps the OSC sequences iTerm2 honors
+ * for native macOS notification banner (OSC 9) and dock-bounce attention
+ * request (OSC 1337 RequestAttention).
+ *
+ * Constructor-injected with a session-escape writer so the capability is
+ * unit-testable in isolation: mock `writeEscape`, run notify(), assert the
+ * OSC bytes that were written.
+ */
+
+import type { NotificationsCapability } from "../capabilities/notifications.js";
+
+export type EscapeWriter = (sessionId: string, escape: string) => Promise<void>;
+
+export class ItermNotifications implements NotificationsCapability {
+  constructor(private readonly writeEscape: EscapeWriter) {}
+
+  async notify(sessionId: string, title: string, body?: string): Promise<void> {
+    // OSC 9 displays a macOS notification banner. iTerm2 reads through to
+    // NSUserNotificationCenter when a profile permits it.
+    const msg = body ? `${title}: ${body}` : title;
+    await this.writeEscape(sessionId, `\x1b]9;${msg}\x07`);
+  }
+
+  async flash(sessionId: string): Promise<void> {
+    // OSC 1337 RequestAttention=fireworks bounces the iTerm2 dock icon.
+    await this.writeEscape(sessionId, "\x1b]1337;RequestAttention=fireworks\x07");
+  }
+}

--- a/src/iterm.ts
+++ b/src/iterm.ts
@@ -40,6 +40,23 @@ export async function currentSessionId(): Promise<string> {
 }
 
 /**
+ * Get the iTerm2 session ID of the FIRST session of the current tab. This is
+ * the stable identifier we use to match crew-tracked tabs (tabs.iterm_session_id
+ * is stamped from the initial pane's session id at create-tab time). The
+ * current session may be any pane in the tab; the first session anchors the
+ * tab identity.
+ */
+export async function currentTabFirstSessionId(): Promise<string> {
+  return osascript(`
+    tell application "iTerm2"
+      tell current tab of current window
+        return id of first session
+      end tell
+    end tell
+  `);
+}
+
+/**
  * Get the iTerm2 session ID for the session owning a specific TTY.
  * More reliable than ITERM_SESSION_ID env var which can go stale.
  */

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -447,6 +447,11 @@ export async function startServer(): Promise<void> {
       inputSchema: { type: "object" as const, properties: {} },
     },
     {
+      name: "tab_active",
+      description: "Return the crew-tracked tab the operator is currently viewing, or null if the focused tab is not crew-tracked or can't be determined. Use this before spawning a new pane to land it where the operator's eyes are, instead of creating a fresh tab they have to switch to.",
+      inputSchema: { type: "object" as const, properties: {} },
+    },
+    {
       name: "tab_destroy",
       description: "Destroy a tab and all its panes. Agents in those panes are detached (keep running headless). NEVER destroy a tab containing a pane you are sitting in.",
       inputSchema: {
@@ -764,6 +769,9 @@ export async function startServer(): Promise<void> {
           break;
         case "tab_list":
           result = orchestrator.listTabs();
+          break;
+        case "tab_active":
+          result = { tab: await orchestrator.activeTab() };
           break;
         case "tab_destroy":
           orchestrator.deleteTab(a.name as string);

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -30,11 +30,16 @@ const { Orchestrator } = await import("./orchestrator");
 // install behavior; default is empty (`capability("...")` returns null).
 const terminalCapabilities: Record<string, unknown> = {};
 
+// Mutable state for the terminal mock so tests can flip what currentTabId
+// reports without re-mocking the entire backend per case.
+const terminalState = { currentTabId: null as string | null };
+
 function makeTerminal(): TerminalBackend {
   return {
     name: "test",
     capability: ((name: string) => (terminalCapabilities[name] ?? null)) as TerminalBackend["capability"],
     currentSessionId: mock(async () => ""),
+    currentTabId: mock(async () => terminalState.currentTabId),
     sessionIdForTty: mock(async () => null),
     splitPane: mock(async () => ""),
     splitSession: mock(async () => ""),
@@ -541,6 +546,38 @@ describe("attachAgent screen-liveness guard", () => {
     } finally {
       screenState.isAliveResult = false;
     }
+  });
+});
+
+describe("activeTab introspection", () => {
+  test("returns the crew tab whose iterm_session_id matches the focused tab", async () => {
+    orch.store.createTab("eng", undefined, "workspace:3");
+    orch.store.createTab("ops", undefined, "workspace:4");
+    terminalState.currentTabId = "workspace:3";
+    try {
+      const active = await orch.activeTab();
+      expect(active?.name).toBe("eng");
+    } finally {
+      terminalState.currentTabId = null;
+    }
+  });
+
+  test("returns null when the focused tab is not crew-tracked", async () => {
+    orch.store.createTab("eng", undefined, "workspace:3");
+    terminalState.currentTabId = "workspace:99"; // some manually-opened cmux ws
+    try {
+      const active = await orch.activeTab();
+      expect(active).toBeNull();
+    } finally {
+      terminalState.currentTabId = null;
+    }
+  });
+
+  test("returns null when the backend can't resolve a focused tab", async () => {
+    orch.store.createTab("eng", undefined, "workspace:3");
+    terminalState.currentTabId = null; // backend returned null
+    const active = await orch.activeTab();
+    expect(active).toBeNull();
   });
 });
 

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -25,9 +25,15 @@ mock.module("./screen", () => ({
 
 const { Orchestrator } = await import("./orchestrator");
 
+// Mutable capability registry for the terminal mock. Individual tests can
+// set `terminalCapabilities.notifications = { notify: ..., flash: ... }` to
+// install behavior; default is empty (`capability("...")` returns null).
+const terminalCapabilities: Record<string, unknown> = {};
+
 function makeTerminal(): TerminalBackend {
   return {
     name: "test",
+    capability: ((name: string) => (terminalCapabilities[name] ?? null)) as TerminalBackend["capability"],
     currentSessionId: mock(async () => ""),
     sessionIdForTty: mock(async () => null),
     splitPane: mock(async () => ""),

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -51,6 +51,7 @@ function makeTerminal(): TerminalBackend {
     deletePaneProfile: mock(() => {}),
     setProfile: mock(async () => {}),
     sendText: mock(async () => {}),
+    attachScreen: mock(async () => {}),
   } as unknown as TerminalBackend;
 }
 
@@ -503,6 +504,43 @@ describe("resumeAgent", () => {
     expect(cmd).not.toContain("--resume");
     expect(cmd).toContain("cd '/tmp/nb'");
     expect(cmd).toContain("AGENT_ID='never-booted'");
+  });
+});
+
+describe("attachAgent screen-liveness guard", () => {
+  // Regression: pre-fix, attachAgent silently 'succeeded' against a dead
+  // screen session. Operator sees a blank pane and a green API response.
+  // Loom hit this 2026-05-23 — see feedback-screen-zombie-listings.
+  test("throws when the agent's screen session is dead", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "ghost", AGENT_NAME: "Ghost" } });
+    orch.store.createTab("eng");
+    const pane = orch.store.createPane("oak", "eng");
+    orch.store.setPaneItermId(pane.name, "iterm-session-123");
+
+    screenState.isAliveResult = false; // screen is dead
+    try {
+      await expect(orch.attachAgent("ghost", "oak"))
+        .rejects.toThrow(/screen session 'wire-ghost' is dead/);
+    } finally {
+      screenState.isAliveResult = false;
+    }
+  });
+
+  test("attaches normally when the screen session is alive", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "alive-agent", AGENT_NAME: "AliveAgent" } });
+    orch.store.createTab("eng");
+    const pane = orch.store.createPane("oak", "eng");
+    orch.store.setPaneItermId(pane.name, "iterm-session-456");
+
+    screenState.isAliveResult = true;
+    try {
+      await orch.attachAgent("alive-agent", "oak");
+      // Liveness guard should pass; pane assignment lands on the row.
+      const row = orch.store.getAgent("alive-agent");
+      expect(row?.pane).toBe("oak");
+    } finally {
+      screenState.isAliveResult = false;
+    }
   });
 });
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1089,6 +1089,30 @@ export class Orchestrator {
     return this.store.listTabs();
   }
 
+  /**
+   * Return the crew-tracked tab the operator is currently viewing, or null
+   * if no tracked tab matches the focused workspace/window. Used by
+   * placement-aware spawn flows: bridge.spawn can call this to land a new
+   * pane in the operator's current tab instead of creating an orphan tab
+   * they have to switch to manually.
+   *
+   * Returns null in three cases: (a) the terminal backend can't resolve a
+   * focused tab (no window in focus, AppleScript denied, etc.); (b) the
+   * focused tab is not crew-tracked (e.g., a shell tab the operator opened
+   * manually); (c) the backend's currentTabId returned a value that doesn't
+   * match any tab.iterm_session_id. Callers treating null as "place into a
+   * fresh tab" preserve the pre-fix behavior.
+   *
+   * See [[draft-crew-tools-papercuts-from-loom]] §2 for the surfacing
+   * incident (loom 2026-05-23 spawning heddle into a new tab while Brian
+   * watched a different tab).
+   */
+  async activeTab(): Promise<Tab | null> {
+    const tabId = await this.terminal.currentTabId();
+    if (!tabId) return null;
+    return this.store.listTabs().find((t) => t.iterm_session_id === tabId) ?? null;
+  }
+
   deleteTab(name: string): void {
     this.store.deleteTab(name);
   }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -704,6 +704,18 @@ export class Orchestrator {
     const agent = this.store.getAgent(agentId);
     if (!agent) throw new Error(`agent '${agentId}' not found`);
 
+    // Verify the screen session is actually alive. attachAgent used to
+    // silently no-op (screen.detachSession is .nothrow(), and screen -r
+    // against a dead session fails only inside the pane), so the API would
+    // claim success while the operator stared at a blank pane. Loom hit this
+    // 2026-05-23 attaching heddle whose screen had died during 21h of idle.
+    if (!(await screen.isAlive(agent.screen_name))) {
+      throw new Error(
+        `agent '${agentId}' screen session '${agent.screen_name}' is dead. ` +
+        `Run reconcile to prune the stale row, then re-spawn the agent.`,
+      );
+    }
+
     // Auto-swap to a themed pane if needed
     const resolvedPane = await this.ensureThemedPane(paneName);
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -738,19 +738,25 @@ export class Orchestrator {
       // Non-fatal
     }
 
-    // Flash the tab and notify — agent is now visible.
-    // On cmux these are native; on iTerm2 flash is a no-op and notify
-    // falls back to setBadge, so the agent badge below must run AFTER
-    // to reclaim the badge slot.
-    try {
-      await this.terminal.flashSession(pane.iterm_id);
-      await this.terminal.notifySession(pane.iterm_id, `${agent.display_name} attached`, `→ pane ${resolvedPane}`);
-    } catch (e) {
-      console.error(`[crew] attach flash/notify failed for '${agentId}' on '${resolvedPane}':`, e);
+    // Flash the tab and notify — agent is now visible. Both cmux and iTerm2
+    // register the Notifications capability with real native implementations
+    // (cmux native OS notification + tab ring; iTerm2 OSC 9 banner + OSC
+    // 1337 RequestAttention). Backends without the capability skip silently.
+    const notifications = this.terminal.capability("notifications");
+    if (notifications) {
+      try {
+        await notifications.flash(pane.iterm_id);
+        await notifications.notify(
+          pane.iterm_id,
+          `${agent.display_name} attached`,
+          `→ pane ${resolvedPane}`,
+        );
+      } catch (e) {
+        console.error(`[crew] attach flash/notify failed for '${agentId}' on '${resolvedPane}':`, e);
+      }
     }
 
     // Apply the agent's badge to the pane (color from pane's profile, text from agent).
-    // Runs AFTER notifySession so it wins on iTerm2 (where notify falls back to setBadge).
     if (agent.badge) {
       try {
         await this.terminal.setBadge(pane.iterm_id, agent.badge);

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -62,7 +62,21 @@ export async function reconcile(
 
     knownScreenNames.add(agent.screen_name);
     const session = sessionByName.get(agent.screen_name);
+    // Two-step liveness check. `screen -ls` lists zombie sessions briefly
+    // after process death, until screen GCs the socket. Without the kill(pid,
+    // 0) cross-check, the reconciler touches a dead agent as alive and the
+    // stale row poisons downstream operations (agent_list, attach). Loom hit
+    // this 2026-05-23 with heddle after a 21h-idle screen death.
+    let isLive = false;
     if (session) {
+      try {
+        process.kill(session.pid, 0);
+        isLive = true;
+      } catch {
+        isLive = false;
+      }
+    }
+    if (isLive && session) {
       store.updateAgentPid(agent.id, session.pid);
       store.touchAgent(agent.id);
       alive.push(agent.id);

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -124,9 +124,22 @@ export async function isAttached(name: string): Promise<boolean> {
 
 /**
  * Check if a screen session is alive.
+ *
+ * Belt-and-suspenders: `screen -ls` will list a zombie session briefly after
+ * its process dies, until screen GCs the socket. Cross-check the pid with
+ * `kill(pid, 0)` so callers (attach, reconciler) don't trust a stale listing
+ * and end up operating on a dead session. Loom hit this 2026-05-23 — see
+ * `feedback-screen-zombie-listings` for the incident.
  */
 export async function isAlive(name: string): Promise<boolean> {
-  return (await getSessionPid(name)) !== null;
+  const pid = await getSessionPid(name);
+  if (pid === null) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -5,6 +5,8 @@
  * so the orchestrator and MCP server are terminal-agnostic.
  */
 
+import type { CapabilityMap } from "./capabilities/types.js";
+
 /**
  * Profile info for creating themed panes.
  * iTerm2 uses dynamic profiles with background images.
@@ -22,10 +24,32 @@ export interface PaneProfile {
 /**
  * Common interface for terminal backends.
  * Both iTerm2 and cmux implement this.
+ *
+ * Methods marked `@deprecated` are part of Phase 1 of the capability split
+ * migration ([[plan-terminal-capabilities-split]]). They remain as thin
+ * shims that delegate to the corresponding capability on backends that
+ * register it; new callers should use `terminal.capability("name")?.op(...)`
+ * directly. Phase 2 (next major) drops the shims.
  */
 export interface TerminalBackend {
   /** Human-readable backend name (for logs/errors). */
   readonly name: string;
+
+  /**
+   * Look up an optional capability by name. Returns the implementation if
+   * the backend registered it, or `null` if it didn't. Use this to test
+   * for and access features that don't apply to every backend (themed
+   * profiles on iTerm2, sidebar log on cmux, etc.).
+   *
+   *   const notif = terminal.capability("notifications");
+   *   if (notif) await notif.notify(sessionId, "Agent attached");
+   *
+   * Callers that want a fallback when the capability is absent should
+   * write the branch explicitly at the call site rather than expecting the
+   * backend to fake the operation. See `src/capabilities/types.ts` for the
+   * full registry and the design rationale.
+   */
+  capability<K extends keyof CapabilityMap>(name: K): CapabilityMap[K] | null;
 
   // --- Identity ---
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -56,6 +56,20 @@ export interface TerminalBackend {
   /** Get the session/surface ID of the current (focused) terminal. */
   currentSessionId(): Promise<string>;
 
+  /**
+   * Get the tab/workspace ID of the focused tab — i.e. where the operator's
+   * eyes are. Matches the `iterm_session_id` column in `crews.db.tabs` for
+   * crew-tracked tabs.
+   *
+   * Returns null if the active tab can't be resolved (no focused window,
+   * AppleScript denied, cmux daemon unreachable, etc.). Callers should
+   * treat null as "unknown — fall back to default placement."
+   *
+   * cmux: returns the focused workspace's ref (e.g. "workspace:3").
+   * iTerm2: returns the id of the first session in the current tab.
+   */
+  currentTabId(): Promise<string | null>;
+
   /** Resolve a TTY device path to a session/surface ID. */
   sessionIdForTty(ttyName: string): Promise<string | null>;
 


### PR DESCRIPTION
## Summary

Three orthogonal improvements that all surfaced from a single session of operator-side incident-driven work on 2026-05-23. Bundling them into one PR because they share a version bump and share blast radius (orchestrator + reconciler + terminal interface). Each commit is independently reviewable and was originally drafted as a standalone PR.

### Commit 1 — `feat(capabilities): introduce capability registry + Notifications`

The first slice of the terminal-backend capability split. The single ever-growing \`TerminalBackend\` interface was pretending cmux and iTerm2 are equivalent products — every cmux-side feature landed as a no-op stub on iTerm, every iTerm-side primitive (themed profiles, badge colors) was dead weight on cmux.

This commit introduces \`terminal.capability(name)\` as the new accessor and ships the first capability (\`Notifications\`):

- \`src/capabilities/types.ts\` — typed CapabilityMap registry.
- \`src/capabilities/notifications.ts\` — first capability interface.
- \`src/capabilities/notifications.contract.ts\` — shared contract every backend's \`NotificationsCapability\` must pass.
- \`src/cmux-capabilities/notifications.ts\` — cmux native impl (wraps \`cmux notify\` + \`cmux trigger-flash\`).
- \`src/iterm-capabilities/notifications.ts\` — iTerm2 native impl (OSC 9 banner for notify, OSC 1337 RequestAttention for flash).
- Constructor-injected dependencies so each capability is unit-testable in isolation.
- Unit tests + the shared contract suite run against both backends.
- Integration tests gated on environment (\`existsSync(CMUX_BUNDLED_CLI_PATH)\` / \`ITERM_SESSION_ID\` set) — Brian runs cmux side, Tim runs iTerm side; CI doesn't.

Both backends register \`Notifications\` with real native implementations. The old \`notifySession\` / \`flashSession\` methods remain as thin \`@deprecated\` shims that delegate to the capability (preserves backward compat). Orchestrator's \`attachAgent\` switched from \`terminal.flashSession\` / \`notifySession\` to \`terminal.capability(\"notifications\")?.flash\` / \`notify\`.

**Principle**: *absence beats degraded behavior when the fallback changes user-visible state*. A capability advertises the semantic operation, not a clever approximation. Callers that want a fallback write \`capability(\"X\")?.op(...) ?? core.fallbackOp(...)\` so the product decision is visible at the call site.

Design + rationale: Kiln-validated 2026-05-23 with two passes (capability-split chosen over fork or new npm package; refined migration shape with type-level deprecation, scan-driven Phase 2 gate, capability-symmetry for iTerm-native features).

### Commit 2 — \`fix(reconcile): cross-check screen pid with kill(pid,0); guard attach on dead screens\`

Three crew paths trusted \`screen -ls\` as the sole liveness signal and operated on dead screen sessions. The fix is a single canonical liveness check (\`kill(pid, 0)\` on top of the screen-ls pid) applied in all three places:

- \`screen.isAlive\` now cross-checks the pid with \`process.kill(pid, 0)\` after looking it up via \`screen -ls\`.
- \`reconciler\` agent loop does the same kill-check inline.
- \`orchestrator.attachAgent\` calls \`screen.isAlive\` up front and throws a clear error if the session is dead — previously it silently no-op'd because \`detachSession\` is \`.nothrow()\` and \`terminal.attachScreen\` surfaces errors only inside the pane.

**Why**: \`screen -ls\` lists zombie sessions for a brief window after process death, until screen GCs the socket. Loom hit all three symptoms on 2026-05-23 attaching heddle whose screen had died during ~21h of idle. \`agent_list\` returned heddle as alive, \`reconcile\` reported him attached, \`agent_attach\` claimed success — pane stayed blank.

### Commit 3 — \`feat(crew): tab_active — resolve the operator's focused tab to a crew tab\`

Adds the primitive crew needed for placement-aware spawning:

- \`TerminalBackend.currentTabId(): Promise<string | null>\` — new interface method.
- \`CmuxBackend\`: returns \`focused.workspace_ref\` from \`cmux identify\`.
- \`ItermBackend\`: returns the id of the first session of the current tab.
- \`Orchestrator.activeTab(): Promise<Tab | null>\` — resolves backend id → crew Tab.
- MCP tool \`tab_active\` — exposes it to callers.

**Why**: when loom spawned heddle 2026-05-23, \`tab_list\` returned \`[]\`. Correct interpretation: \"no crew-tracked tabs.\" Misleading-by-omission: \"no tabs in iTerm/cmux.\" Loom (reasonably) created a fresh tab; Brian was looking at a different one and had to switch manually. The fix is a primitive query that returns the focused tab or null.

## What stays untouched

- Bridge — calls crew through MCP tools, which are runtime-agnostic. \`Orchestrator\` public API doesn't change shape. Zero churn.
- Wire / knowledge / seance — independent systems.
- crew-claude-code / crew-codex — no consumer changes required (no consumer calls the deprecated methods directly; everyone uses the MCP tool surface).
- MCP tool schema + stored crews.db rows + cc_session_id values — stable.

## Test plan

- [x] \`bun test\` — 124 pass / 3 skip / 0 fail (was 101). Added 17 capability unit + contract tests (8 cmux, 9 iterm), 2 reconcile-liveness regression tests, 3 activeTab tests, 4 integration test scaffolding stubs (skipped in CI; run on operator boxes).
- [ ] Brian-side: \`bun test src/cmux-capabilities/notifications.integration.test.ts\` from \`~/NewProjects/crew-tools\` — visual confirmation that the cmux native notification + tab-ring flash actually fire.
- [ ] Tim-side (when ready): \`bun test src/iterm-capabilities/notifications.integration.test.ts\` from inside an iTerm2 session — visual confirmation of OSC 9 banner + OSC 1337 dock-bounce.
- [ ] (post-merge) End-to-end via a real \`agent_attach\` — orchestrator hits \`capability(\"notifications\")?.flash\` / \`notify\` from production code path.

## Migration notes for downstream

- Existing callers of \`terminal.notifySession\` / \`flashSession\` continue to work (Phase 1 \`@deprecated\` shims).
- New callers should use \`terminal.capability(\"notifications\")?.notify(sessionId, title, body)\` / \`.flash(sessionId)\`.
- Phase 2 (next major v3.0.0) drops the shims. Acceptance gate for Phase 2: zero first-party imports of deprecated methods + automated consumer-plugin scan complete (per Kiln's review).

## Risk

Low-to-medium.

- **Capability split (commit 1)**: pure addition + thin shims. Backward compatibility preserved. New surface area is opt-in.
- **Reconcile fix (commit 2)**: tighter liveness check; anything that would have been reported as dead before is still dead now, anything that was a zombie now correctly resolves as dead. The attach guard changes API behavior — callers attempting to attach a dead-screen agent now throw with guidance instead of silently no-op'ing. Strictly more informative.
- **tab_active (commit 3)**: pure addition. New interface method (both backends implement, default to null on resolution failure), new orchestrator method, new MCP tool.

## Source context

- Capability-split plan: \`.knowledge/plan-terminal-capabilities-split.md\` in fondant's vault. Kiln second-pass review captured at seq=302 on the wire.
- Loom's papercut report (origin of the reconcile-fix + tab_active items): \`.knowledge/draft-crew-tools-papercuts-from-loom.md\`.

🤖 Generated by 🧰 SweetFondant (Brian-side fondant clone)