### PR TITLE
crew-tools v2.13.0 — finish the capability burndown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/capabilities/profiles.ts
+++ b/src/capabilities/profiles.ts
@@ -1,0 +1,60 @@
+/**
+ * Profiles capability — themed dynamic profiles for a terminal session.
+ * Backgrounds, blends, modes, and badge-color overlays. iTerm2's native
+ * dynamic-profile system.
+ *
+ * iTerm2 registers this. cmux does not (cmux uses sidebar metadata for
+ * the same UX; the dynamic-profile-with-background-image concept doesn't
+ * apply). Per-pane decorations on cmux should be expressed through the
+ * `BadgeColors` capability and operator-side cmux themes, not through
+ * dynamic profiles.
+ */
+
+export interface PaneProfileSpec {
+  paneName: string;
+  backgroundImage?: string;
+  blend?: number;
+  mode?: number;
+  badgeColor?: { r: number; g: number; b: number; a?: number };
+}
+
+export interface ProfilesCapability {
+  /**
+   * Write a pane profile to disk and return the profile name for use with
+   * setProfile / splitPaneWithProfile / splitSessionWithProfile.
+   */
+  writePane(profile: PaneProfileSpec): string;
+
+  /**
+   * Write the empty/default pane profile and return its name. Used when
+   * a pane should look default but still go through the dynamic-profile
+   * mechanism for consistency with themed siblings.
+   */
+  writeEmpty(): string;
+
+  /**
+   * Apply a named profile to an existing session (iTerm2: OSC 1337
+   * SetProfile=).
+   */
+  setProfile(sessionId: string, profileName: string): Promise<void>;
+
+  /**
+   * Split the current pane using a named profile. Returns the new session
+   * ID. The current pane is implicit (uses iTerm2's "current session of
+   * current tab").
+   */
+  splitPaneWithProfile(
+    direction: "horizontal" | "vertical",
+    profileName: string,
+  ): Promise<string>;
+
+  /**
+   * Split a specific session using a named profile. Returns the new session
+   * ID.
+   */
+  splitSessionWithProfile(
+    sessionId: string,
+    direction: "horizontal" | "vertical",
+    profileName: string,
+  ): Promise<string>;
+}

--- a/src/capabilities/sidebar-log.ts
+++ b/src/capabilities/sidebar-log.ts
@@ -1,0 +1,24 @@
+/**
+ * SidebarLog capability — append-only workspace-level log entries that show
+ * up in the terminal's sidebar UI. Used to surface agent lifecycle events
+ * (attached, closed, error) where the operator can see them at a glance
+ * without opening the pane.
+ *
+ * cmux registers this with a native sidebar log. iTerm2 has no equivalent
+ * and does not register the capability; callers branch on absence.
+ */
+
+export type SidebarLogLevel = "info" | "progress" | "success" | "warning" | "error";
+
+export interface SidebarLogCapability {
+  /**
+   * Append a workspace-level log entry. Failures are non-fatal — logging is
+   * decorative. The capability swallows transport errors internally so
+   * callers can fire-and-forget.
+   */
+  append(
+    sessionId: string,
+    message: string,
+    opts?: { level?: SidebarLogLevel; source?: string },
+  ): Promise<void>;
+}

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -20,6 +20,7 @@
 import type { NotificationsCapability } from "./notifications.js";
 import type { SidebarLogCapability } from "./sidebar-log.js";
 import type { WorkspaceControlCapability } from "./workspace-control.js";
+import type { WorkspaceSplitCapability } from "./workspace-split.js";
 
 /**
  * The canonical registry of capability names → implementation types.
@@ -35,6 +36,7 @@ export interface CapabilityMap {
   notifications: NotificationsCapability;
   sidebarLog: SidebarLogCapability;
   workspaceControl: WorkspaceControlCapability;
+  workspaceSplit: WorkspaceSplitCapability;
 }
 
 /**

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -19,6 +19,7 @@
 
 import type { NotificationsCapability } from "./notifications.js";
 import type { SidebarLogCapability } from "./sidebar-log.js";
+import type { WorkspaceControlCapability } from "./workspace-control.js";
 
 /**
  * The canonical registry of capability names → implementation types.
@@ -33,6 +34,7 @@ import type { SidebarLogCapability } from "./sidebar-log.js";
 export interface CapabilityMap {
   notifications: NotificationsCapability;
   sidebarLog: SidebarLogCapability;
+  workspaceControl: WorkspaceControlCapability;
 }
 
 /**

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -18,6 +18,7 @@
  */
 
 import type { NotificationsCapability } from "./notifications.js";
+import type { SidebarLogCapability } from "./sidebar-log.js";
 
 /**
  * The canonical registry of capability names → implementation types.
@@ -31,6 +32,7 @@ import type { NotificationsCapability } from "./notifications.js";
  */
 export interface CapabilityMap {
   notifications: NotificationsCapability;
+  sidebarLog: SidebarLogCapability;
 }
 
 /**

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -21,6 +21,7 @@ import type { NotificationsCapability } from "./notifications.js";
 import type { SidebarLogCapability } from "./sidebar-log.js";
 import type { WorkspaceControlCapability } from "./workspace-control.js";
 import type { WorkspaceSplitCapability } from "./workspace-split.js";
+import type { ProfilesCapability } from "./profiles.js";
 
 /**
  * The canonical registry of capability names → implementation types.
@@ -37,6 +38,7 @@ export interface CapabilityMap {
   sidebarLog: SidebarLogCapability;
   workspaceControl: WorkspaceControlCapability;
   workspaceSplit: WorkspaceSplitCapability;
+  profiles: ProfilesCapability;
 }
 
 /**

--- a/src/capabilities/workspace-control.ts
+++ b/src/capabilities/workspace-control.ts
@@ -1,0 +1,11 @@
+/**
+ * WorkspaceControl capability — operations that manipulate the
+ * workspace/tab container surrounding a session.
+ *
+ * cmux registers this with its native workspace API. iTerm2 does not
+ * (iTerm2 tab naming is limited; callers branch on absence).
+ */
+export interface WorkspaceControlCapability {
+  /** Rename the workspace containing the given session. */
+  rename(sessionId: string, name: string): Promise<void>;
+}

--- a/src/capabilities/workspace-split.ts
+++ b/src/capabilities/workspace-split.ts
@@ -1,0 +1,20 @@
+/**
+ * WorkspaceSplit capability — split the caller's surface in-place to create
+ * a sibling pane in the caller's workspace. Used by spawn flows that want a
+ * new agent to land next to the caller's surface rather than in a fresh tab.
+ *
+ * cmux registers this via `cmux new-split`. iTerm2 does not (agents are
+ * launched into detached screen sessions and attached separately, which has
+ * no notion of "split from caller's session").
+ */
+export interface WorkspaceSplitCapability {
+  /**
+   * Split the caller's surface and return the new surface's ref. Returns
+   * null if the caller's surface can't be resolved or the split fails —
+   * the caller treats null as "best-effort failed; agent stays headless."
+   */
+  splitFromCaller(
+    callerSurfaceId: string,
+    direction: "right" | "down",
+  ): Promise<string | null>;
+}

--- a/src/cmux-capabilities/profiles.test.ts
+++ b/src/cmux-capabilities/profiles.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from "bun:test";
+import { CmuxProfiles, type CmuxProfilesDeps } from "./profiles";
+
+function makeDeps(): {
+  deps: CmuxProfilesDeps;
+  calls: { splitPane: any[]; splitSession: any[]; apply: any[] };
+} {
+  const calls = { splitPane: [] as any[], splitSession: [] as any[], apply: [] as any[] };
+  const deps: CmuxProfilesDeps = {
+    splitPane: async (d) => {
+      calls.splitPane.push(d);
+      return "surface:new";
+    },
+    splitSession: async (sid, d) => {
+      calls.splitSession.push({ sid, d });
+      return "surface:new-from";
+    },
+    applyToSurface: async (sid, profile) => {
+      calls.apply.push({ sid, profile });
+    },
+  };
+  return { deps, calls };
+}
+
+describe("CmuxProfiles", () => {
+  test("writePane stores profile under a synthetic name", () => {
+    const { deps } = makeDeps();
+    const impl = new CmuxProfiles(deps);
+    const name1 = impl.writePane({ paneName: "oak", backgroundImage: "/img/oak.png" });
+    const name2 = impl.writePane({ paneName: "elm", backgroundImage: "/img/elm.png" });
+    expect(name1).toMatch(/^cmux-profile-0-oak$/);
+    expect(name2).toMatch(/^cmux-profile-1-elm$/);
+  });
+
+  test("writeEmpty returns 'cmux-empty' (no store entry)", () => {
+    const { deps } = makeDeps();
+    const impl = new CmuxProfiles(deps);
+    expect(impl.writeEmpty()).toBe("cmux-empty");
+  });
+
+  test("setProfile applies the stored spec via applyToSurface", async () => {
+    const { deps, calls } = makeDeps();
+    const impl = new CmuxProfiles(deps);
+    const name = impl.writePane({ paneName: "oak", backgroundImage: "/img/oak.png", blend: 0.5 });
+    await impl.setProfile("surface:7", name);
+    expect(calls.apply).toEqual([
+      { sid: "surface:7", profile: { paneName: "oak", backgroundImage: "/img/oak.png", blend: 0.5 } },
+    ]);
+  });
+
+  test("setProfile no-ops when profile name not in store", async () => {
+    const { deps, calls } = makeDeps();
+    const impl = new CmuxProfiles(deps);
+    await impl.setProfile("surface:7", "cmux-empty");
+    expect(calls.apply).toEqual([]);
+  });
+
+  test("splitPaneWithProfile splits then applies", async () => {
+    const { deps, calls } = makeDeps();
+    const impl = new CmuxProfiles(deps);
+    const name = impl.writePane({ paneName: "oak", backgroundImage: "/img/oak.png" });
+    const result = await impl.splitPaneWithProfile("horizontal", name);
+    expect(result).toBe("surface:new");
+    expect(calls.splitPane).toEqual(["horizontal"]);
+    expect(calls.apply[0].sid).toBe("surface:new");
+  });
+
+  test("splitSessionWithProfile splits then applies", async () => {
+    const { deps, calls } = makeDeps();
+    const impl = new CmuxProfiles(deps);
+    const name = impl.writePane({ paneName: "oak", backgroundImage: "/img/oak.png" });
+    const result = await impl.splitSessionWithProfile("surface:src", "vertical", name);
+    expect(result).toBe("surface:new-from");
+    expect(calls.splitSession).toEqual([{ sid: "surface:src", d: "vertical" }]);
+    expect(calls.apply[0].sid).toBe("surface:new-from");
+  });
+});

--- a/src/cmux-capabilities/profiles.ts
+++ b/src/cmux-capabilities/profiles.ts
@@ -1,0 +1,76 @@
+/**
+ * cmux Profiles capability — wraps cmux's surface.set_background RPC.
+ *
+ * cmux has no on-disk dynamic-profile concept like iTerm2; instead it
+ * accepts per-surface background images via RPC. The capability emulates
+ * the "write profile, then apply by name" shape by maintaining an
+ * in-memory map from synthetic profile names to PaneProfileSpec objects.
+ * setProfile / split-with-profile look up the spec by name and fire the RPC.
+ *
+ * Constructor-injected with the backend operations the capability needs
+ * (splitPane / splitSession base ops + an applyToSurface callback that
+ * does the PTY-wait + RPC dance).
+ */
+
+import type {
+  PaneProfileSpec,
+  ProfilesCapability,
+} from "../capabilities/profiles.js";
+
+export interface CmuxProfilesDeps {
+  splitPane: (direction: "horizontal" | "vertical") => Promise<string>;
+  splitSession: (
+    sessionId: string,
+    direction: "horizontal" | "vertical",
+  ) => Promise<string>;
+  /**
+   * Apply a PaneProfileSpec's background to a session via cmux RPC.
+   * Implementations should wait for PTY + log+swallow failures.
+   * Called when no profile is present in the map, the cap silently no-ops.
+   */
+  applyToSurface: (sessionId: string, profile: PaneProfileSpec) => Promise<void>;
+}
+
+export class CmuxProfiles implements ProfilesCapability {
+  private readonly profileStore = new Map<string, PaneProfileSpec>();
+  private profileSeq = 0;
+
+  constructor(private readonly deps: CmuxProfilesDeps) {}
+
+  writePane(profile: PaneProfileSpec): string {
+    const name = `cmux-profile-${this.profileSeq++}-${profile.paneName}`;
+    this.profileStore.set(name, profile);
+    return name;
+  }
+
+  writeEmpty(): string {
+    // Empty profile means "no background" — represented as a name with no
+    // entry in the store, so setProfile lookup misses and no-ops.
+    return "cmux-empty";
+  }
+
+  async setProfile(sessionId: string, profileName: string): Promise<void> {
+    const profile = this.profileStore.get(profileName);
+    if (!profile) return;
+    await this.deps.applyToSurface(sessionId, profile);
+  }
+
+  async splitPaneWithProfile(
+    direction: "horizontal" | "vertical",
+    profileName: string,
+  ): Promise<string> {
+    const sessionId = await this.deps.splitPane(direction);
+    await this.setProfile(sessionId, profileName);
+    return sessionId;
+  }
+
+  async splitSessionWithProfile(
+    sessionId: string,
+    direction: "horizontal" | "vertical",
+    profileName: string,
+  ): Promise<string> {
+    const newSessionId = await this.deps.splitSession(sessionId, direction);
+    await this.setProfile(newSessionId, profileName);
+    return newSessionId;
+  }
+}

--- a/src/cmux-capabilities/sidebar-log.test.ts
+++ b/src/cmux-capabilities/sidebar-log.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from "bun:test";
+import { CmuxSidebarLog, type CmuxCli, type WorkspaceResolver } from "./sidebar-log";
+
+function makeMocks(opts: { wsRef?: string | null; cliThrows?: Error } = {}) {
+  const calls: string[][] = [];
+  const cli: CmuxCli = async (...args) => {
+    calls.push(args);
+    if (opts.cliThrows) throw opts.cliThrows;
+    return "OK";
+  };
+  const resolveWorkspace: WorkspaceResolver = async () => opts.wsRef ?? null;
+  return { cli, resolveWorkspace, calls };
+}
+
+describe("CmuxSidebarLog", () => {
+  test("append invokes 'cmux log' with default source=crew, no workspace if unresolved", async () => {
+    const { cli, resolveWorkspace, calls } = makeMocks({ wsRef: null });
+    const impl = new CmuxSidebarLog(cli, resolveWorkspace);
+    await impl.append("surface:7", "agent attached");
+    expect(calls).toEqual([["log", "--source", "crew", "--", "agent attached"]]);
+  });
+
+  test("append includes --workspace when resolver returns a workspace", async () => {
+    const { cli, resolveWorkspace, calls } = makeMocks({ wsRef: "workspace:3" });
+    const impl = new CmuxSidebarLog(cli, resolveWorkspace);
+    await impl.append("surface:7", "hello");
+    expect(calls[0]).toContain("--workspace");
+    expect(calls[0]).toContain("workspace:3");
+  });
+
+  test("append passes --level when provided", async () => {
+    const { cli, resolveWorkspace, calls } = makeMocks({ wsRef: "workspace:3" });
+    const impl = new CmuxSidebarLog(cli, resolveWorkspace);
+    await impl.append("surface:7", "fail", { level: "error" });
+    expect(calls[0]).toContain("--level");
+    expect(calls[0]).toContain("error");
+  });
+
+  test("append swallows CLI errors (decorative)", async () => {
+    const { cli, resolveWorkspace } = makeMocks({ cliThrows: new Error("cmux not running") });
+    const impl = new CmuxSidebarLog(cli, resolveWorkspace);
+    await expect(impl.append("surface:7", "msg")).resolves.toBeUndefined();
+  });
+});

--- a/src/cmux-capabilities/sidebar-log.ts
+++ b/src/cmux-capabilities/sidebar-log.ts
@@ -1,0 +1,38 @@
+/**
+ * cmux SidebarLog capability — wraps `cmux log`, which writes workspace-
+ * level sidebar entries that the operator sees without opening any specific
+ * pane. Constructor-injected with the cmux CLI and a workspace-ref resolver
+ * so it's unit-testable in isolation.
+ */
+
+import type {
+  SidebarLogCapability,
+  SidebarLogLevel,
+} from "../capabilities/sidebar-log.js";
+
+export type CmuxCli = (...args: string[]) => Promise<string>;
+export type WorkspaceResolver = (sessionId: string) => Promise<string | null>;
+
+export class CmuxSidebarLog implements SidebarLogCapability {
+  constructor(
+    private readonly cli: CmuxCli,
+    private readonly resolveWorkspace: WorkspaceResolver,
+  ) {}
+
+  async append(
+    sessionId: string,
+    message: string,
+    opts?: { level?: SidebarLogLevel; source?: string },
+  ): Promise<void> {
+    try {
+      const wsRef = await this.resolveWorkspace(sessionId);
+      const wsFlag = wsRef ? ["--workspace", wsRef] : [];
+      const levelFlag = opts?.level ? ["--level", opts.level] : [];
+      const sourceFlag = ["--source", opts?.source ?? "crew"];
+      // cmux log puts the message after `--`, supporting messages that start with `-`.
+      await this.cli("log", ...wsFlag, ...levelFlag, ...sourceFlag, "--", message);
+    } catch {
+      // Non-fatal — sidebar log is decorative.
+    }
+  }
+}

--- a/src/cmux-capabilities/workspace-control.test.ts
+++ b/src/cmux-capabilities/workspace-control.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from "bun:test";
+import { CmuxWorkspaceControl, type CmuxCli, type CmuxJsonCli } from "./workspace-control";
+
+function makeMocks(opts: { tree?: any; cliThrows?: Error } = {}) {
+  const calls: string[][] = [];
+  const cli: CmuxCli = async (...args) => {
+    calls.push(args);
+    if (opts.cliThrows) throw opts.cliThrows;
+    return "OK";
+  };
+  const jsonCli: CmuxJsonCli = async () => opts.tree ?? { windows: [] };
+  return { cli, jsonCli, calls };
+}
+
+describe("CmuxWorkspaceControl", () => {
+  test("rename resolves the workspace from the tree and invokes rename-workspace", async () => {
+    const tree = {
+      windows: [
+        {
+          workspaces: [
+            { ref: "workspace:3", panes: [{ surfaces: [{ ref: "surface:7" }] }] },
+            { ref: "workspace:4", panes: [{ surfaces: [{ ref: "surface:9" }] }] },
+          ],
+        },
+      ],
+    };
+    const { cli, jsonCli, calls } = makeMocks({ tree });
+    const impl = new CmuxWorkspaceControl(cli, jsonCli);
+    await impl.rename("surface:9", "engineering");
+    expect(calls).toEqual([["rename-workspace", "--workspace", "workspace:4", "engineering"]]);
+  });
+
+  test("rename no-ops silently when the surface isn't in the tree", async () => {
+    const { cli, jsonCli, calls } = makeMocks({ tree: { windows: [] } });
+    const impl = new CmuxWorkspaceControl(cli, jsonCli);
+    await impl.rename("surface:missing", "foo");
+    expect(calls).toEqual([]);
+  });
+
+  test("rename swallows CLI errors (decorative)", async () => {
+    const tree = {
+      windows: [
+        { workspaces: [{ ref: "workspace:3", panes: [{ surfaces: [{ ref: "surface:7" }] }] }] },
+      ],
+    };
+    const { cli, jsonCli } = makeMocks({ tree, cliThrows: new Error("cmux gone") });
+    const impl = new CmuxWorkspaceControl(cli, jsonCli);
+    await expect(impl.rename("surface:7", "x")).resolves.toBeUndefined();
+  });
+});

--- a/src/cmux-capabilities/workspace-control.ts
+++ b/src/cmux-capabilities/workspace-control.ts
@@ -1,0 +1,38 @@
+/**
+ * cmux WorkspaceControl capability — wraps `cmux rename-workspace`.
+ * Constructor-injected with a CLI invoker and a JSON-returning CLI invoker
+ * for tree introspection (used to map sessionId → workspace ref).
+ */
+
+import type { WorkspaceControlCapability } from "../capabilities/workspace-control.js";
+
+export type CmuxCli = (...args: string[]) => Promise<string>;
+export type CmuxJsonCli = (...args: string[]) => Promise<any>;
+
+export class CmuxWorkspaceControl implements WorkspaceControlCapability {
+  constructor(
+    private readonly cli: CmuxCli,
+    private readonly jsonCli: CmuxJsonCli,
+  ) {}
+
+  async rename(sessionId: string, name: string): Promise<void> {
+    try {
+      // Find which workspace this surface belongs to.
+      const tree = await this.jsonCli("tree");
+      for (const win of tree.windows ?? []) {
+        for (const ws of win.workspaces ?? []) {
+          for (const pane of ws.panes ?? []) {
+            for (const surface of pane.surfaces ?? []) {
+              if (surface.ref === sessionId) {
+                await this.cli("rename-workspace", "--workspace", ws.ref, name);
+                return;
+              }
+            }
+          }
+        }
+      }
+    } catch {
+      // Non-fatal — rename is decorative.
+    }
+  }
+}

--- a/src/cmux-capabilities/workspace-split.test.ts
+++ b/src/cmux-capabilities/workspace-split.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from "bun:test";
+import { CmuxWorkspaceSplit, type CmuxCli, type SurfaceResolver } from "./workspace-split";
+
+function makeMocks(opts: {
+  resolved?: { ref: string; ws: string | null; id: string | null } | null;
+  cliResult?: string;
+  cliThrows?: Error;
+} = {}) {
+  const calls: string[][] = [];
+  const cli: CmuxCli = async (...args) => {
+    calls.push(args);
+    if (opts.cliThrows) throw opts.cliThrows;
+    return opts.cliResult ?? "OK surface:42 workspace:3";
+  };
+  const resolveSurface: SurfaceResolver = async () => opts.resolved ?? null;
+  return { cli, resolveSurface, calls };
+}
+
+describe("CmuxWorkspaceSplit", () => {
+  test("splitFromCaller invokes new-split with resolved surface + workspace", async () => {
+    const { cli, resolveSurface, calls } = makeMocks({
+      resolved: { ref: "surface:7", ws: "workspace:3", id: null },
+    });
+    const impl = new CmuxWorkspaceSplit(cli, resolveSurface);
+    const result = await impl.splitFromCaller("surface:7", "right");
+    expect(calls).toEqual([["new-split", "right", "--surface", "surface:7", "--workspace", "workspace:3"]]);
+    expect(result).toBe("surface:42");
+  });
+
+  test("splitFromCaller returns null when caller surface unresolved", async () => {
+    const { cli, resolveSurface, calls } = makeMocks({ resolved: null });
+    const impl = new CmuxWorkspaceSplit(cli, resolveSurface);
+    const result = await impl.splitFromCaller("surface:bogus", "right");
+    expect(result).toBeNull();
+    expect(calls).toEqual([]);
+  });
+
+  test("splitFromCaller returns null when CLI throws", async () => {
+    const { cli, resolveSurface } = makeMocks({
+      resolved: { ref: "surface:7", ws: "workspace:3", id: null },
+      cliThrows: new Error("cmux down"),
+    });
+    const impl = new CmuxWorkspaceSplit(cli, resolveSurface);
+    const result = await impl.splitFromCaller("surface:7", "down");
+    expect(result).toBeNull();
+  });
+
+  test("splitFromCaller passes direction 'down' through correctly", async () => {
+    const { cli, resolveSurface, calls } = makeMocks({
+      resolved: { ref: "surface:7", ws: null, id: null },
+    });
+    const impl = new CmuxWorkspaceSplit(cli, resolveSurface);
+    await impl.splitFromCaller("surface:7", "down");
+    expect(calls[0]).toEqual(["new-split", "down", "--surface", "surface:7"]);
+  });
+});

--- a/src/cmux-capabilities/workspace-split.ts
+++ b/src/cmux-capabilities/workspace-split.ts
@@ -1,0 +1,44 @@
+/**
+ * cmux WorkspaceSplit capability — wraps `cmux new-split`. Constructor-
+ * injected with a CLI invoker and a surface resolver (for strict pre-check
+ * to avoid orphan surfaces in the focused workspace when the caller's ref
+ * is stale).
+ */
+
+import type { WorkspaceSplitCapability } from "../capabilities/workspace-split.js";
+
+export type CmuxCli = (...args: string[]) => Promise<string>;
+export type SurfaceResolver = (
+  input: string,
+) => Promise<{ ref: string; ws: string | null; id: string | null } | null>;
+
+export class CmuxWorkspaceSplit implements WorkspaceSplitCapability {
+  constructor(
+    private readonly cli: CmuxCli,
+    private readonly resolveSurface: SurfaceResolver,
+  ) {}
+
+  async splitFromCaller(
+    callerSurfaceId: string,
+    direction: "right" | "down",
+  ): Promise<string | null> {
+    // Strict resolve: placement next to caller only makes sense if caller's
+    // surface actually exists. Unlike per-surface ops on possibly-stale refs
+    // (which surfaceArgs lets through so cmux returns "Surface not found"),
+    // cmux new-split silently ignores an unknown --surface and creates an
+    // orphan surface in the focused workspace. Fail fast instead.
+    const resolved = await this.resolveSurface(callerSurfaceId);
+    if (!resolved) return null;
+    try {
+      const cmuxDir = direction === "right" ? "right" : "down";
+      const args = resolved.ws
+        ? ["--surface", resolved.ref, "--workspace", resolved.ws]
+        : ["--surface", resolved.ref];
+      const output = await this.cli("new-split", cmuxDir, ...args);
+      const match = output.match(/surface:\d+/);
+      return match ? match[0] : null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -19,6 +19,7 @@ import { CmuxNotifications } from "./cmux-capabilities/notifications.js";
 import { CmuxSidebarLog } from "./cmux-capabilities/sidebar-log.js";
 import { CmuxWorkspaceControl } from "./cmux-capabilities/workspace-control.js";
 import { CmuxWorkspaceSplit } from "./cmux-capabilities/workspace-split.js";
+import { CmuxProfiles } from "./cmux-capabilities/profiles.js";
 
 // Capability registration deferred to constructor (needs class-private
 // `surfaceArgs` / `resolveSurface` bindings). Fields declared, populated
@@ -82,14 +83,6 @@ function mapProfileToRpcParams(
 export class CmuxBackend implements TerminalBackend {
   readonly name = "cmux" as const;
 
-  /**
-   * In-memory profile store. iTerm2 persists profiles to disk; cmux has no
-   * dynamic-profile concept, so we stash PaneProfile objects under synthetic
-   * names and resolve them when setProfile() / splitWithProfile() fire.
-   */
-  private profileStore = new Map<string, PaneProfile>();
-  private profileSeq = 0;
-
   private readonly _capabilities: CapabilityRegistry;
 
   constructor() {
@@ -101,6 +94,31 @@ export class CmuxBackend implements TerminalBackend {
       ),
       workspaceControl: new CmuxWorkspaceControl(cmux, cmuxJson),
       workspaceSplit: new CmuxWorkspaceSplit(cmux, (s) => this.resolveSurface(s)),
+      profiles: new CmuxProfiles({
+        splitPane: (d) => this.splitPane(d),
+        splitSession: (sid, d) => this.splitSession(sid, d),
+        applyToSurface: async (sid, profile) => {
+          // Use cmux's RPC pipeline: wait for PTY, resolve UUID, fire.
+          if (!profile.backgroundImage) return;
+          await this.waitForPty(sid);
+          const resolved = await this.resolveSurface(sid);
+          if (!resolved?.id) {
+            console.error(`[crew] cmux set-background skipped: cannot resolve UUID for ${sid}`);
+            return;
+          }
+          const params = mapProfileToRpcParams(
+            resolved.id,
+            profile.backgroundImage,
+            profile.blend,
+            profile.mode,
+          );
+          try {
+            await cmux("rpc", "surface.set_background", JSON.stringify(params));
+          } catch (e) {
+            console.error(`[crew] cmux set-background failed for ${sid} (${resolved.id}): ${e instanceof Error ? e.message : String(e)}`);
+          }
+        },
+      }),
     };
   }
 
@@ -232,36 +250,6 @@ export class CmuxBackend implements TerminalBackend {
       await new Promise((r) => setTimeout(r, 50));
     }
     return false;
-  }
-
-  /**
-   * Apply a stored profile's background to a surface via cmux's RPC.
-   * Best-effort — failures (cmux down, surface gone, malformed image path)
-   * are logged but never thrown. Matches the rest of this class's policy.
-   *
-   * Polls briefly for PTY allocation before firing the RPC. See waitForPty
-   * for why.
-   */
-  private async applyProfileToSurface(sessionId: string, profileName: string): Promise<void> {
-    const profile = this.profileStore.get(profileName);
-    if (!profile || !profile.backgroundImage) return;
-    await this.waitForPty(sessionId);
-    const resolved = await this.resolveSurface(sessionId);
-    if (!resolved?.id) {
-      console.error(`[crew] cmux set-background skipped: cannot resolve UUID for ${sessionId}`);
-      return;
-    }
-    const params = mapProfileToRpcParams(
-      resolved.id,
-      profile.backgroundImage,
-      profile.blend,
-      profile.mode,
-    );
-    try {
-      await cmux("rpc", "surface.set_background", JSON.stringify(params));
-    } catch (e) {
-      console.error(`[crew] cmux set-background failed for ${sessionId} (${resolved.id}): ${e instanceof Error ? e.message : String(e)}`);
-    }
   }
 
   async currentSessionId(): Promise<string> {
@@ -420,7 +408,7 @@ export class CmuxBackend implements TerminalBackend {
     }
     const result = surfaceRef ?? wsRef;
     if (profileName && surfaceRef) {
-      await this.applyProfileToSurface(surfaceRef, profileName);
+      await this.capability("profiles")!.setProfile(surfaceRef, profileName);
     }
     return result;
   }
@@ -497,41 +485,36 @@ export class CmuxBackend implements TerminalBackend {
     await this.capability("workspaceControl")?.rename(sessionId, name);
   }
 
+  /** @deprecated Phase 1 shim. Use `capability("profiles")?.writePane(...)`. Removed in v3.0.0. */
   writePaneProfile(profile: PaneProfile): string {
-    // cmux has no on-disk dynamic-profile concept — stash in memory and
-    // apply when the new surface exists (in setProfile / splitWithProfile).
-    const name = `cmux-profile-${this.profileSeq++}-${profile.paneName}`;
-    this.profileStore.set(name, profile);
-    return name;
+    return this.capability("profiles")!.writePane(profile);
   }
 
+  /** @deprecated Phase 1 shim. Use `capability("profiles")?.writeEmpty()`. Removed in v3.0.0. */
   writeEmptyPaneProfile(): string {
-    // Empty profile means "no background" — represented as a name with no
-    // entry in the store, so applyProfileToSurface no-ops on lookup.
-    return "cmux-empty";
+    return this.capability("profiles")!.writeEmpty();
   }
 
+  /** @deprecated Phase 1 shim. Use `capability("profiles")?.setProfile(...)`. Removed in v3.0.0. */
   async setProfile(sessionId: string, profileName: string): Promise<void> {
-    await this.applyProfileToSurface(sessionId, profileName);
+    await this.capability("profiles")!.setProfile(sessionId, profileName);
   }
 
+  /** @deprecated Phase 1 shim. Use `capability("profiles")?.splitPaneWithProfile(...)`. Removed in v3.0.0. */
   async splitPaneWithProfile(
     direction: "horizontal" | "vertical",
     profileName: string,
   ): Promise<string> {
-    const sessionId = await this.splitPane(direction);
-    await this.applyProfileToSurface(sessionId, profileName);
-    return sessionId;
+    return this.capability("profiles")!.splitPaneWithProfile(direction, profileName);
   }
 
+  /** @deprecated Phase 1 shim. Use `capability("profiles")?.splitSessionWithProfile(...)`. Removed in v3.0.0. */
   async splitSessionWithProfile(
     sessionId: string,
     direction: "horizontal" | "vertical",
     profileName: string,
   ): Promise<string> {
-    const newSessionId = await this.splitSession(sessionId, direction);
-    await this.applyProfileToSurface(newSessionId, profileName);
-    return newSessionId;
+    return this.capability("profiles")!.splitSessionWithProfile(sessionId, direction, profileName);
   }
 
   async splitWebBrowser(

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -17,6 +17,7 @@ import type { TerminalBackend, PaneProfile } from "./terminal.js";
 import type { CapabilityMap, CapabilityRegistry } from "./capabilities/types.js";
 import { CmuxNotifications } from "./cmux-capabilities/notifications.js";
 import { CmuxSidebarLog } from "./cmux-capabilities/sidebar-log.js";
+import { CmuxWorkspaceControl } from "./cmux-capabilities/workspace-control.js";
 
 // Capability registration deferred to constructor (needs class-private
 // `surfaceArgs` / `resolveSurface` bindings). Fields declared, populated
@@ -97,6 +98,7 @@ export class CmuxBackend implements TerminalBackend {
         cmux,
         async (sid) => (await this.resolveSurface(sid))?.ws ?? null,
       ),
+      workspaceControl: new CmuxWorkspaceControl(cmux, cmuxJson),
     };
   }
 
@@ -485,25 +487,12 @@ export class CmuxBackend implements TerminalBackend {
     await this.capability("notifications")?.notify(sessionId, title, body);
   }
 
+  /**
+   * @deprecated Phase 1 shim. Use `capability("workspaceControl")?.rename(...)`.
+   * Removed in v3.0.0.
+   */
   async renameWorkspace(sessionId: string, name: string): Promise<void> {
-    try {
-      // Find which workspace this surface belongs to
-      const tree = await cmuxJson("tree");
-      for (const win of tree.windows ?? []) {
-        for (const ws of win.workspaces ?? []) {
-          for (const pane of ws.panes ?? []) {
-            for (const surface of pane.surfaces ?? []) {
-              if (surface.ref === sessionId) {
-                await cmux("rename-workspace", "--workspace", ws.ref, name);
-                return;
-              }
-            }
-          }
-        }
-      }
-    } catch {
-      // Non-fatal
-    }
+    await this.capability("workspaceControl")?.rename(sessionId, name);
   }
 
   writePaneProfile(profile: PaneProfile): string {

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -16,9 +16,11 @@ import { $ } from "bun";
 import type { TerminalBackend, PaneProfile } from "./terminal.js";
 import type { CapabilityMap, CapabilityRegistry } from "./capabilities/types.js";
 import { CmuxNotifications } from "./cmux-capabilities/notifications.js";
+import { CmuxSidebarLog } from "./cmux-capabilities/sidebar-log.js";
 
 // Capability registration deferred to constructor (needs class-private
-// `surfaceArgs` binding). Field declared, populated in constructor.
+// `surfaceArgs` / `resolveSurface` bindings). Fields declared, populated
+// in constructor.
 
 /**
  * Run a cmux CLI command and return trimmed stdout.
@@ -91,6 +93,10 @@ export class CmuxBackend implements TerminalBackend {
   constructor() {
     this._capabilities = {
       notifications: new CmuxNotifications(cmux, (sid) => this.surfaceArgs(sid)),
+      sidebarLog: new CmuxSidebarLog(
+        cmux,
+        async (sid) => (await this.resolveSurface(sid))?.ws ?? null,
+      ),
     };
   }
 
@@ -431,21 +437,16 @@ export class CmuxBackend implements TerminalBackend {
    *
    * iTerm2 backend leaves this undefined; orchestrator skips the call there.
    */
+  /**
+   * @deprecated Phase 1 shim. Use `capability("sidebarLog")?.append(...)`.
+   * Removed in v3.0.0.
+   */
   async logWorkspace(
     sessionId: string,
     message: string,
     opts?: { level?: "info" | "progress" | "success" | "warning" | "error"; source?: string },
   ): Promise<void> {
-    try {
-      const wsRef = (await this.resolveSurface(sessionId))?.ws ?? null;
-      const wsFlag = wsRef ? ["--workspace", wsRef] : [];
-      const levelFlag = opts?.level ? ["--level", opts.level] : [];
-      const sourceFlag = ["--source", opts?.source ?? "crew"];
-      // cmux log puts the message after `--`, supporting messages that start with `-`.
-      await cmux("log", ...wsFlag, ...levelFlag, ...sourceFlag, "--", message);
-    } catch {
-      // Non-fatal — sidebar log is decorative.
-    }
+    await this.capability("sidebarLog")?.append(sessionId, message, opts);
   }
 
   async setBadge(sessionId: string, text: string): Promise<void> {

--- a/src/cmux.ts
+++ b/src/cmux.ts
@@ -18,6 +18,7 @@ import type { CapabilityMap, CapabilityRegistry } from "./capabilities/types.js"
 import { CmuxNotifications } from "./cmux-capabilities/notifications.js";
 import { CmuxSidebarLog } from "./cmux-capabilities/sidebar-log.js";
 import { CmuxWorkspaceControl } from "./cmux-capabilities/workspace-control.js";
+import { CmuxWorkspaceSplit } from "./cmux-capabilities/workspace-split.js";
 
 // Capability registration deferred to constructor (needs class-private
 // `surfaceArgs` / `resolveSurface` bindings). Fields declared, populated
@@ -99,6 +100,7 @@ export class CmuxBackend implements TerminalBackend {
         async (sid) => (await this.resolveSurface(sid))?.ws ?? null,
       ),
       workspaceControl: new CmuxWorkspaceControl(cmux, cmuxJson),
+      workspaceSplit: new CmuxWorkspaceSplit(cmux, (s) => this.resolveSurface(s)),
     };
   }
 
@@ -569,27 +571,14 @@ export class CmuxBackend implements TerminalBackend {
    * surface invalid, cmux split refused, etc.). The orchestrator treats
    * a null return as "best-effort failed — keep the agent headless."
    */
+  /**
+   * @deprecated Phase 1 shim. Use `capability("workspaceSplit")?.splitFromCaller(...)`.
+   * Removed in v3.0.0.
+   */
   async splitFromCallerForAgent(
     callerSurfaceId: string,
     direction: "right" | "down",
   ): Promise<string | null> {
-    // Strict resolve: placement next to caller only makes sense if caller's
-    // surface actually exists. Unlike per-surface ops on possibly-stale refs
-    // (which surfaceArgs lets through so cmux can return "Surface not found"),
-    // cmux new-split silently ignores an unknown --surface and creates an
-    // orphan surface in the focused workspace. Fail fast instead.
-    const resolved = await this.resolveSurface(callerSurfaceId);
-    if (!resolved) return null;
-    try {
-      const cmuxDir = direction === "right" ? "right" : "down";
-      const args = resolved.ws
-        ? ["--surface", resolved.ref, "--workspace", resolved.ws]
-        : ["--surface", resolved.ref];
-      const output = await cmux("new-split", cmuxDir, ...args);
-      const match = output.match(/surface:\d+/);
-      return match ? match[0] : null;
-    } catch {
-      return null;
-    }
+    return (await this.capability("workspaceSplit")?.splitFromCaller(callerSurfaceId, direction)) ?? null;
   }
 }

--- a/src/iterm-backend.ts
+++ b/src/iterm-backend.ts
@@ -6,12 +6,20 @@ import type { TerminalBackend, PaneProfile } from "./terminal.js";
 import type { CapabilityMap, CapabilityRegistry } from "./capabilities/types.js";
 import * as iterm from "./iterm.js";
 import { ItermNotifications } from "./iterm-capabilities/notifications.js";
+import { ItermProfiles } from "./iterm-capabilities/profiles.js";
 
 export class ItermBackend implements TerminalBackend {
   readonly name = "iterm" as const;
 
   private readonly _capabilities: CapabilityRegistry = {
     notifications: new ItermNotifications(iterm.writeEscapeToSession),
+    profiles: new ItermProfiles({
+      writePaneProfile: iterm.writePaneProfile,
+      writeEmptyPaneProfile: iterm.writeEmptyPaneProfile,
+      writeEscapeToSession: iterm.writeEscapeToSession,
+      splitPaneWithProfile: iterm.splitPaneWithProfile,
+      splitSessionWithProfile: iterm.splitSessionWithProfile,
+    }),
   };
 
   capability<K extends keyof CapabilityMap>(name: K): CapabilityMap[K] | null {
@@ -83,41 +91,36 @@ export class ItermBackend implements TerminalBackend {
     return iterm.setBadge(sessionId, text);
   }
 
+  /** @deprecated Phase 1 shim. Use `capability("profiles")?.writePane(...)`. Removed in v3.0.0. */
   writePaneProfile(profile: PaneProfile): string {
-    if (!profile.backgroundImage) {
-      iterm.writeEmptyPaneProfile();
-      return "Crew Empty Pane";
-    }
-    return iterm.writePaneProfile(profile.paneName, profile.backgroundImage, {
-      blend: profile.blend,
-      mode: profile.mode,
-      badgeColor: profile.badgeColor,
-    });
+    return this.capability("profiles")!.writePane(profile);
   }
 
+  /** @deprecated Phase 1 shim. Use `capability("profiles")?.writeEmpty()`. Removed in v3.0.0. */
   writeEmptyPaneProfile(): string {
-    iterm.writeEmptyPaneProfile();
-    return "Crew Empty Pane";
+    return this.capability("profiles")!.writeEmpty();
   }
 
+  /** @deprecated Phase 1 shim. Use `capability("profiles")?.setProfile(...)`. Removed in v3.0.0. */
   async setProfile(sessionId: string, profileName: string): Promise<void> {
-    // OSC 1337 SetProfile= switches the session to a named (dynamic) profile.
-    await iterm.writeEscapeToSession(sessionId, `\x1b]1337;SetProfile=${profileName}\x07`);
+    await this.capability("profiles")!.setProfile(sessionId, profileName);
   }
 
+  /** @deprecated Phase 1 shim. Use `capability("profiles")?.splitPaneWithProfile(...)`. Removed in v3.0.0. */
   splitPaneWithProfile(
     direction: "horizontal" | "vertical",
     profileName: string,
   ): Promise<string> {
-    return iterm.splitPaneWithProfile(direction, profileName);
+    return this.capability("profiles")!.splitPaneWithProfile(direction, profileName);
   }
 
+  /** @deprecated Phase 1 shim. Use `capability("profiles")?.splitSessionWithProfile(...)`. Removed in v3.0.0. */
   splitSessionWithProfile(
     sessionId: string,
     direction: "horizontal" | "vertical",
     profileName: string,
   ): Promise<string> {
-    return iterm.splitSessionWithProfile(sessionId, direction, profileName);
+    return this.capability("profiles")!.splitSessionWithProfile(sessionId, direction, profileName);
   }
 
   /**

--- a/src/iterm-backend.ts
+++ b/src/iterm-backend.ts
@@ -136,8 +136,13 @@ export class ItermBackend implements TerminalBackend {
     await this.capability("notifications")?.notify(sessionId, title, body);
   }
 
+  /**
+   * @deprecated Phase 1 shim. iTerm2 doesn't register `workspaceControl`
+   * (tab naming is limited); callers should query `capability("workspaceControl")`
+   * and branch on null. Removed in v3.0.0.
+   */
   async renameWorkspace(_sessionId: string, _name: string): Promise<void> {
-    // iTerm2 tab naming is limited — see setTabName
+    // No-op; iTerm2 doesn't register WorkspaceControl.
   }
 
   splitWebBrowser(

--- a/src/iterm-capabilities/profiles.test.ts
+++ b/src/iterm-capabilities/profiles.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect, mock } from "bun:test";
+import { ItermProfiles, type ItermProfilesDeps } from "./profiles";
+
+function makeDeps(overrides: Partial<ItermProfilesDeps> = {}): {
+  deps: ItermProfilesDeps;
+  calls: {
+    writePane: any[];
+    writeEmpty: any[];
+    escape: Array<{ sessionId: string; escape: string }>;
+    splitPane: any[];
+    splitSession: any[];
+  };
+} {
+  const calls = {
+    writePane: [] as any[],
+    writeEmpty: [] as any[],
+    escape: [] as Array<{ sessionId: string; escape: string }>,
+    splitPane: [] as any[],
+    splitSession: [] as any[],
+  };
+  const deps: ItermProfilesDeps = {
+    writePaneProfile: mock((paneName: string, bg: string, opts: any) => {
+      calls.writePane.push({ paneName, bg, opts });
+      return `Crew ${paneName}`;
+    }),
+    writeEmptyPaneProfile: mock(() => {
+      calls.writeEmpty.push({});
+    }),
+    writeEscapeToSession: mock(async (sessionId: string, escape: string) => {
+      calls.escape.push({ sessionId, escape });
+    }),
+    splitPaneWithProfile: mock(async (direction: any, profileName: string) => {
+      calls.splitPane.push({ direction, profileName });
+      return "iterm:new-session";
+    }),
+    splitSessionWithProfile: mock(async (sessionId: string, direction: any, profileName: string) => {
+      calls.splitSession.push({ sessionId, direction, profileName });
+      return "iterm:new-session-from";
+    }),
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+describe("ItermProfiles", () => {
+  test("writePane delegates to writePaneProfile when backgroundImage present", () => {
+    const { deps, calls } = makeDeps();
+    const impl = new ItermProfiles(deps);
+    const name = impl.writePane({ paneName: "oak", backgroundImage: "/img/oak.png", blend: 0.5 });
+    expect(name).toBe("Crew oak");
+    expect(calls.writePane).toEqual([{ paneName: "oak", bg: "/img/oak.png", opts: { blend: 0.5, mode: undefined, badgeColor: undefined } }]);
+  });
+
+  test("writePane falls back to empty when no backgroundImage", () => {
+    const { deps, calls } = makeDeps();
+    const impl = new ItermProfiles(deps);
+    const name = impl.writePane({ paneName: "oak" });
+    expect(name).toBe("Crew Empty Pane");
+    expect(calls.writeEmpty).toHaveLength(1);
+    expect(calls.writePane).toEqual([]);
+  });
+
+  test("writeEmpty returns 'Crew Empty Pane'", () => {
+    const { deps, calls } = makeDeps();
+    const impl = new ItermProfiles(deps);
+    expect(impl.writeEmpty()).toBe("Crew Empty Pane");
+    expect(calls.writeEmpty).toHaveLength(1);
+  });
+
+  test("setProfile writes OSC 1337 SetProfile=", async () => {
+    const { deps, calls } = makeDeps();
+    const impl = new ItermProfiles(deps);
+    await impl.setProfile("iterm:session:abc", "Crew oak");
+    expect(calls.escape).toEqual([{ sessionId: "iterm:session:abc", escape: "\x1b]1337;SetProfile=Crew oak\x07" }]);
+  });
+
+  test("splitPaneWithProfile delegates to dep", async () => {
+    const { deps, calls } = makeDeps();
+    const impl = new ItermProfiles(deps);
+    const result = await impl.splitPaneWithProfile("horizontal", "Crew oak");
+    expect(result).toBe("iterm:new-session");
+    expect(calls.splitPane).toEqual([{ direction: "horizontal", profileName: "Crew oak" }]);
+  });
+
+  test("splitSessionWithProfile delegates to dep", async () => {
+    const { deps, calls } = makeDeps();
+    const impl = new ItermProfiles(deps);
+    const result = await impl.splitSessionWithProfile("iterm:src", "vertical", "Crew oak");
+    expect(result).toBe("iterm:new-session-from");
+    expect(calls.splitSession).toEqual([{ sessionId: "iterm:src", direction: "vertical", profileName: "Crew oak" }]);
+  });
+});

--- a/src/iterm-capabilities/profiles.ts
+++ b/src/iterm-capabilities/profiles.ts
@@ -1,0 +1,82 @@
+/**
+ * iTerm2 Profiles capability — wraps the dynamic-profile lifecycle: writing
+ * pane profile JSON to disk, applying a profile via OSC 1337, and creating
+ * panes seeded with a named profile.
+ *
+ * The transport surface is pure iterm.ts module functions (osascript +
+ * filesystem writes). Constructor-injected with the iterm module so the
+ * capability is unit-testable in isolation: mock the module, run
+ * writePane(), assert what got written.
+ */
+
+import type {
+  PaneProfileSpec,
+  ProfilesCapability,
+} from "../capabilities/profiles.js";
+
+export interface ItermProfilesDeps {
+  writePaneProfile: (
+    paneName: string,
+    backgroundImage: string,
+    opts: {
+      blend?: number;
+      mode?: number;
+      badgeColor?: { r: number; g: number; b: number; a?: number };
+    },
+  ) => string;
+  writeEmptyPaneProfile: () => void;
+  writeEscapeToSession: (sessionId: string, escape: string) => Promise<void>;
+  splitPaneWithProfile: (
+    direction: "horizontal" | "vertical",
+    profileName: string,
+  ) => Promise<string>;
+  splitSessionWithProfile: (
+    sessionId: string,
+    direction: "horizontal" | "vertical",
+    profileName: string,
+  ) => Promise<string>;
+}
+
+export class ItermProfiles implements ProfilesCapability {
+  constructor(private readonly deps: ItermProfilesDeps) {}
+
+  writePane(profile: PaneProfileSpec): string {
+    if (!profile.backgroundImage) {
+      this.deps.writeEmptyPaneProfile();
+      return "Crew Empty Pane";
+    }
+    return this.deps.writePaneProfile(profile.paneName, profile.backgroundImage, {
+      blend: profile.blend,
+      mode: profile.mode,
+      badgeColor: profile.badgeColor,
+    });
+  }
+
+  writeEmpty(): string {
+    this.deps.writeEmptyPaneProfile();
+    return "Crew Empty Pane";
+  }
+
+  async setProfile(sessionId: string, profileName: string): Promise<void> {
+    // OSC 1337 SetProfile= switches the session to a named (dynamic) profile.
+    await this.deps.writeEscapeToSession(
+      sessionId,
+      `\x1b]1337;SetProfile=${profileName}\x07`,
+    );
+  }
+
+  splitPaneWithProfile(
+    direction: "horizontal" | "vertical",
+    profileName: string,
+  ): Promise<string> {
+    return this.deps.splitPaneWithProfile(direction, profileName);
+  }
+
+  splitSessionWithProfile(
+    sessionId: string,
+    direction: "horizontal" | "vertical",
+    profileName: string,
+  ): Promise<string> {
+    return this.deps.splitSessionWithProfile(sessionId, direction, profileName);
+  }
+}

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -238,11 +238,12 @@ export class Orchestrator {
     // stopAgent can tear the pane down alongside the agent. Otherwise the
     // pane lingers showing an exited screen session after the agent dies.
     let auxSurface: string | undefined;
-    if (opts.splitInCallerWorkspace && this.terminal.splitFromCallerForAgent) {
+    const workspaceSplit = this.terminal.capability("workspaceSplit");
+    if (opts.splitInCallerWorkspace && workspaceSplit) {
       try {
         const callerId = await this.terminal.currentSessionId();
         if (callerId) {
-          const newSurface = await this.terminal.splitFromCallerForAgent(
+          const newSurface = await workspaceSplit.splitFromCaller(
             callerId,
             opts.splitInCallerWorkspace.direction,
           );

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -595,7 +595,7 @@ export class Orchestrator {
       if (pane?.iterm_id) {
         try { await this.terminal.setBadge(pane.iterm_id, ""); } catch {}
         try {
-          await this.terminal.logWorkspace?.(
+          await this.terminal.capability("sidebarLog")?.append(
             pane.iterm_id,
             `${agent.display_name} closed`,
             { level: "info", source: "crew" },
@@ -659,7 +659,7 @@ export class Orchestrator {
       if (pane?.iterm_id) {
         try { await this.terminal.setBadge(pane.iterm_id, ""); } catch {}
         try {
-          await this.terminal.logWorkspace?.(
+          await this.terminal.capability("sidebarLog")?.append(
             pane.iterm_id,
             `${agent.display_name} stopped (hard-kill)`,
             { level: "warning", source: "crew" },
@@ -738,10 +738,10 @@ export class Orchestrator {
     await this.terminal.attachScreen(pane.iterm_id, agent.screen_name, "x");
     this.store.updateAgentPane(agentId, resolvedPane);
 
-    // Surface the attach in the workspace sidebar log. cmux-only — iTerm2
-    // leaves logWorkspace undefined.
+    // Surface the attach in the workspace sidebar log. Capability is
+    // cmux-only today — iTerm2 backend doesn't register it.
     try {
-      await this.terminal.logWorkspace?.(
+      await this.terminal.capability("sidebarLog")?.append(
         pane.iterm_id,
         `${agent.display_name} attached → ${resolvedPane}`,
         { level: "success", source: "crew" },

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1041,6 +1041,7 @@ export class Orchestrator {
     // On cmux, writePaneProfile is a no-op and createTab ignores profileName.
     let profileName: string | undefined;
     let paneName: string | undefined;
+    const profiles = this.terminal.capability("profiles");
     if (resolvedTheme) {
       const themeConfig = loadTheme(resolvedTheme);
       const usedNames = this.store.listPanes().map((p) => p.name);
@@ -1048,8 +1049,8 @@ export class Orchestrator {
       if (picked && themeConfig) {
         paneName = picked;
         const bgPath = backgroundImagePath(resolvedTheme, picked, themeConfig);
-        if (bgPath) {
-          profileName = this.terminal.writePaneProfile({
+        if (bgPath && profiles) {
+          profileName = profiles.writePane({
             paneName: picked,
             backgroundImage: bgPath,
             blend: themeConfig.background.blend,
@@ -1197,19 +1198,24 @@ export class Orchestrator {
       ? "vertical"
       : "horizontal";
 
-    // Resolve background image and choose the right profile
+    // Resolve background image and choose the right profile. Profiles
+    // capability is registered by both backends with native implementations
+    // (iTerm dynamic profiles + OSC; cmux in-memory map + surface RPC).
     const tabRow = this.store.getTab(tab);
     const theme = tabRow?.theme ? loadTheme(tabRow.theme) : null;
     const bgPath = tabRow?.theme ? backgroundImagePath(tabRow.theme, paneName, theme) : null;
-    const profileName = bgPath
-      ? this.terminal.writePaneProfile({
-          paneName,
-          backgroundImage: bgPath,
-          blend: theme?.background.blend,
-          mode: theme?.background.mode,
-          badgeColor: theme?.badgeColors?.[paneName] ?? theme?.defaultBadgeColor,
-        })
-      : this.terminal.writeEmptyPaneProfile();
+    const profilesCap = this.terminal.capability("profiles");
+    const profileName = profilesCap
+      ? (bgPath
+          ? profilesCap.writePane({
+              paneName,
+              backgroundImage: bgPath,
+              blend: theme?.background.blend,
+              mode: theme?.background.mode,
+              badgeColor: theme?.badgeColors?.[paneName] ?? theme?.defaultBadgeColor,
+            })
+          : profilesCap.writeEmpty())
+      : undefined;
 
     // Brief delay for iTerm2 to pick up the dynamic profile (cmux doesn't need this but it's harmless)
     if (this.terminal.name === "iterm") {
@@ -1245,7 +1251,9 @@ export class Orchestrator {
         `Re-register the pane or tab, or specify a different relative_to.`
       );
     }
-    sessionId = await this.terminal.splitSessionWithProfile(resolvedId, direction, profileName);
+    sessionId = profilesCap && profileName
+      ? await profilesCap.splitSessionWithProfile(resolvedId, direction, profileName)
+      : await this.terminal.splitSession(resolvedId, direction);
 
     const pane = this.store.createPane(paneName, tab, position, tabRow?.theme ?? undefined);
     this.store.setPaneItermId(paneName, sessionId);
@@ -1310,8 +1318,9 @@ export class Orchestrator {
     // Write themed profile
     const theme = targetTab.theme ? loadTheme(targetTab.theme) : null;
     const bgPath = targetTab.theme ? backgroundImagePath(targetTab.theme, paneName, theme) : null;
-    if (bgPath) {
-      const profileName = this.terminal.writePaneProfile({
+    const themeProfiles = this.terminal.capability("profiles");
+    if (bgPath && themeProfiles) {
+      const profileName = themeProfiles.writePane({
         paneName,
         backgroundImage: bgPath,
         blend: theme?.background.blend,
@@ -1319,7 +1328,7 @@ export class Orchestrator {
         badgeColor: theme?.badgeColors?.[paneName] ?? theme?.defaultBadgeColor,
       });
       // Apply to the already-existing session — splitWithProfile wasn't used.
-      await this.terminal.setProfile(sessionId, profileName);
+      await themeProfiles.setProfile(sessionId, profileName);
     }
 
     // Register in DB

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1074,8 +1074,9 @@ export class Orchestrator {
       await this.terminal.setSessionName(sessionId, titleCase(paneName));
     }
 
-    // Name the workspace/tab (cmux: renames workspace; iTerm2: no-op)
-    await this.terminal.renameWorkspace(sessionId, name);
+    // Name the workspace/tab. Capability is cmux-only today — iTerm2
+    // doesn't register it (tab naming is too limited).
+    await this.terminal.capability("workspaceControl")?.rename(sessionId, name);
 
     return { ...tab, pane };
   }

--- a/src/reconciler.test.ts
+++ b/src/reconciler.test.ts
@@ -26,9 +26,26 @@ function makeTerminal(aliveSessionIds: string[]): TerminalBackend & { calls: Ter
     writePaneProfile: [],
     setProfile: [],
   };
+  // Profiles capability — mirrors what cmux/iterm register, but records
+  // calls into the shared `calls` bag for assertion compatibility with the
+  // pre-capability tests.
+  const profilesCap = {
+    writePane: mock((profile: { paneName: string; backgroundImage?: string }) => {
+      calls.writePaneProfile.push({ paneName: profile.paneName, backgroundImage: profile.backgroundImage });
+      return `Crew ${profile.paneName}`;
+    }),
+    writeEmpty: mock(() => "Crew Empty Pane"),
+    setProfile: mock(async (sessionId: string, profileName: string) => {
+      calls.setProfile.push({ sessionId, profileName });
+    }),
+    splitPaneWithProfile: mock(async () => ""),
+    splitSessionWithProfile: mock(async () => ""),
+  };
+  const capabilities: Record<string, unknown> = { profiles: profilesCap };
   const t: TerminalBackend & { calls: TerminalCalls } = {
     name: "test",
     calls,
+    capability: ((name: string) => capabilities[name] ?? null) as TerminalBackend["capability"],
     currentSessionId: mock(async () => ""),
     sessionIdForTty: mock(async () => null),
     splitPane: mock(async () => ""),

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -193,18 +193,23 @@ export async function reconcile(
         }
       }
 
-      // Build the themed profile and apply it to the live session.
+      // Build the themed profile and apply it to the live session. Both
+      // cmux and iTerm2 register the Profiles capability (different
+      // mechanisms: iTerm dynamic profiles + OSC 1337; cmux in-memory map
+      // + surface.set_background RPC). Skip if a backend doesn't register.
+      const profiles = terminal.capability("profiles");
+      if (!profiles) continue;
       const bgPath = backgroundImagePath(original.theme, workingName, themeConfig);
       const badgeColor = themeConfig?.badgeColors?.[workingName] ?? themeConfig?.defaultBadgeColor;
       try {
-        const profileName = terminal.writePaneProfile({
+        const profileName = profiles.writePane({
           paneName: workingName,
           backgroundImage: bgPath ?? undefined,
           blend: themeConfig?.background.blend,
           mode: themeConfig?.background.mode,
           badgeColor,
         });
-        await terminal.setProfile(original.iterm_id, profileName);
+        await profiles.setProfile(original.iterm_id, profileName);
         // SetProfile switches profile attributes but leaves the session title untouched.
         // Always set the session name so live iTerm UI matches the DB pane name.
         await terminal.setSessionName(original.iterm_id, titleCase(workingName));


### PR DESCRIPTION
## Summary

Finishes the terminal-backend capability split started in v2.12.0 (#80). Migrates the remaining four capability classes off the monolithic `TerminalBackend` interface into named capabilities. All backend-specific behavior now lives in `capability(...)` lookups; the legacy methods remain as `@deprecated` shims until v3.0.0.

## What landed

### `SidebarLog` (cmux-only)
- `src/capabilities/sidebar-log.ts` — interface.
- `src/cmux-capabilities/sidebar-log.ts` — wraps `cmux log`. Constructor-injected CLI + workspace resolver.
- iTerm2 does not register (no equivalent UI surface). Callers branch on absence.
- Orchestrator's three `logWorkspace?.` call sites switched to `capability("sidebarLog")?.append(...)`.

### `WorkspaceControl` (cmux-only)
- `src/capabilities/workspace-control.ts` — interface.
- `src/cmux-capabilities/workspace-control.ts` — wraps `cmux rename-workspace` with tree-based workspace resolution. Constructor-injected CLI + jsonCli.
- iTerm2 does not register (tab naming is limited).
- Orchestrator's `createTab` path switched to `capability("workspaceControl")?.rename(...)`.

### `WorkspaceSplit` (cmux-only)
- `src/capabilities/workspace-split.ts` — interface.
- `src/cmux-capabilities/workspace-split.ts` — wraps `cmux new-split` with strict surface pre-check (prevents orphan surfaces in the focused workspace when the caller's ref is stale).
- iTerm2 does not register.
- Orchestrator's `launchAgent` with `splitInCallerWorkspace` switched to `capability("workspaceSplit")?.splitFromCaller(...)`.

### `Profiles` (cmux + iterm, **symmetric**)
Both backends register `Profiles` with real native implementations:

- **iterm**: dynamic profile JSON on disk + OSC 1337 `SetProfile=`. Constructor-injected deps from the iterm module.
- **cmux**: in-memory map of synthetic profile names → `PaneProfileSpec`, applied via `surface.set_background` RPC. Constructor-injected `applyToSurface` callback handles the PTY-wait + UUID-resolve + RPC dance.

The `PaneProfileSpec` interface lives in `capabilities/profiles.ts`. The original `PaneProfile` shape in `terminal.ts` is preserved for the deprecated shims.

Migrated call sites:
- `reconciler.ts` theme block — `capability("profiles")?.writePane` / `setProfile`. Skips entirely if a backend doesn't register profiles.
- `orchestrator.createTab` — same conditional pattern.
- `orchestrator.createPane` — same.
- `orchestrator.swapToThemedPane` — same.

### `BadgeColors` — folded into `Profiles`

Kiln's review suggested `BadgeColors` as a separate iterm-only capability. After tracing the actual code: `badgeColor` is just a field inside the dynamic profile JSON written by iterm's `writePaneProfile`. There's no standalone "set badge color" operation. Pulling it out into a separate capability would be pure ceremony — a capability should advertise a real semantic operation, not just a renamed field. The `badgeColor` field on `PaneProfileSpec` IS the BadgeColors expression. If a standalone setter materializes later, extraction is mechanical.

## What stays untouched

- Bridge — calls crew through MCP tools (runtime-agnostic). Public API of `Orchestrator` doesn't change shape. Zero churn.
- Wire / knowledge / seance / crew-claude-code / crew-codex — all consumer surfaces remain stable.
- MCP tool schema + stored crews.db rows + cc_session_id values — stable.
- `PaneProfile` type in `terminal.ts` — kept for backward-compat with the deprecated shims.

## Test plan

- [x] `bun test` — 147 pass / 3 skip / 0 fail (was 124 at end of v2.12.0).
  - Added 5 cmux-side capability test files (SidebarLog, WorkspaceControl, WorkspaceSplit, Profiles).
  - Added 1 iterm-side capability test file (Profiles).
  - Existing reconciler test mock updated to expose `capability("profiles")` alongside the legacy shape; existing assertions on the calls bag continue to pass.
- [x] CI plugin-check: 2.12.0 → 2.13.0 is a single-segment bump.
- [ ] (Manual, optional) Re-run cmux-side notification integration test on Brian's box to confirm nothing in the Profiles refactor broke notification delivery. `bun test src/cmux-capabilities/notifications.integration.test.ts`.
- [ ] (Manual, Tim-side) iTerm integration tests once Tim's machine pulls. The mocked iterm impl tests cover the OSC + dynamic-profile call shape; live verification confirms iTerm actually honors them.

## Migration notes (Phase 2 prep, no action this PR)

This PR completes Phase 1 of the migration. The remaining work is Phase 2 (v3.0.0):
1. Audit consumer plugins for direct calls to deprecated `backend.notifySession` / `flashSession` / `logWorkspace` / `renameWorkspace` / `splitFromCallerForAgent` / `writePaneProfile` / `writeEmptyPaneProfile` / `setProfile` / `splitPaneWithProfile` / `splitSessionWithProfile`.
2. When the audit comes back clean, drop the shims and bump to 3.0.0.

Per Kiln's review: the Phase 2 gate is automated-scan-driven, not calendar-driven. Don't ship the major until the audit is green.

## Risk

Low. Phase 1 design is pure addition + backward-compat shims:
- Every old method on the backends still exists and still works.
- New `capability("name")` accessor returns the right impl on each backend.
- No call-path semantics changed (asymmetry preserved: features that were cmux-only stay cmux-only).
- New code is opt-in; old code keeps working until v3.0.0.

🤖 Generated by 🧰 SweetFondant