### PR TITLE
launch/resume: source nearest-ancestor .env before the runtime command (v2.15.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterAll, mock } from "bun:test";
-import { mkdtempSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { execSync } from "child_process";
 import { join } from "path";
 import { tmpdir } from "os";
 import type { TerminalBackend } from "./terminal";
@@ -23,7 +24,7 @@ mock.module("./screen", () => ({
   killSession: async () => {},
 }));
 
-const { Orchestrator } = await import("./orchestrator");
+const { Orchestrator, SOURCE_NEAREST_ENV } = await import("./orchestrator");
 
 function makeTerminal(): TerminalBackend {
   return {
@@ -521,6 +522,69 @@ describe("registerAgent id-mismatch safety", () => {
       if (prevSty === undefined) delete process.env.STY;
       else process.env.STY = prevSty;
       screenState.isAliveResult = false;
+    }
+  });
+});
+
+describe("nearest-ancestor .env sourcing (cc-launch.sh fold)", () => {
+  test("launch command sources .env after the env exports, before the runtime command", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "envy" } });
+
+    const cmd = createSessionCalls[0]!.command;
+    expect(cmd).toContain(SOURCE_NEAREST_ENV);
+    const exportsIdx = cmd.indexOf("export AGENT_ID");
+    const sourceIdx = cmd.indexOf(SOURCE_NEAREST_ENV);
+    expect(exportsIdx).toBeGreaterThan(-1);
+    // .env values must win a collision with the forwarded env map —
+    // exactly cc-launch.sh's ordering (exports first, then source).
+    expect(sourceIdx).toBeGreaterThan(exportsIdx);
+    // the runtime command is the tail, after the sourcing
+    expect(cmd.length).toBeGreaterThan(sourceIdx + SOURCE_NEAREST_ENV.length);
+  });
+
+  test("resume command gets the same sourcing", async () => {
+    await orch.resumeAgent({
+      id: "envy2",
+      ccSessionId: "11111111-2222-3333-4444-555555555555",
+      projectDir: "/tmp/envy2-wd",
+    });
+
+    const cmd = createSessionCalls[0]!.command;
+    expect(cmd).toContain(SOURCE_NEAREST_ENV);
+    const sourceIdx = cmd.indexOf(SOURCE_NEAREST_ENV);
+    expect(sourceIdx).toBeGreaterThan(cmd.indexOf("export AGENT_ID"));
+    expect(cmd.indexOf("--resume", sourceIdx)).toBeGreaterThan(sourceIdx);
+  });
+
+  test("the snippet exports vars from the NEAREST ancestor .env in a real shell", () => {
+    const root = mkdtempSync(join(tmpdir(), "envfold-"));
+    try {
+      mkdirSync(join(root, "a", "b"), { recursive: true });
+      writeFileSync(join(root, ".env"), "FOLD_PROBE=root-level\n");
+      writeFileSync(join(root, "a", ".env"), "FOLD_PROBE=nearest-wins\nFOLD_EXPORTED=yes\n");
+
+      const out = execSync(
+        `cd '${join(root, "a", "b")}' && ${SOURCE_NEAREST_ENV} && printf '%s:%s' "$FOLD_PROBE" "$FOLD_EXPORTED"`,
+        { shell: "/bin/sh", encoding: "utf8" },
+      );
+      expect(out).toBe("nearest-wins:yes");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("no .env anywhere up the tree is a clean no-op", () => {
+    // /private/tmp mkdtemp dirs have no ancestor .env until / — but guard
+    // against a stray /tmp/.env on dev machines by probing an unset var.
+    const root = mkdtempSync(join(tmpdir(), "envfold-none-"));
+    try {
+      const out = execSync(
+        `cd '${root}' && ${SOURCE_NEAREST_ENV} && printf '%s' "${"$"}{FOLD_PROBE_ABSENT:-unset}"`,
+        { shell: "/bin/sh", encoding: "utf8" },
+      );
+      expect(out).toBe("unset");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 });

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -64,6 +64,22 @@ function shellEscape(s: string): string {
 }
 
 /**
+ * Source the nearest ancestor `.env` (walking up from the project dir),
+ * exporting everything it defines (set -a). MCP servers declared in
+ * .mcp.json interpolate ${VAR}s (RENDER_API_KEY, DD_API_KEY, …) and the
+ * non-interactive shell screen spawns never fires direnv — without this
+ * those servers see empty values. Ported verbatim from ~/.wire/cc-launch.sh
+ * as part of retiring that script; placement AFTER the env exports
+ * preserves its semantics (a `.env` value wins a collision with the
+ * forwarded env map, exactly as before). Runtime-agnostic: launchers that
+ * also source `.env` themselves just re-export the same values.
+ */
+export const SOURCE_NEAREST_ENV =
+  `d="$PWD"; while [ "$d" != "/" ]; do ` +
+  `if [ -f "$d/.env" ]; then set -a; . "$d/.env"; set +a; break; fi; ` +
+  `d=$(dirname "$d"); done`;
+
+/**
  * Extract the recorded aux_surface (caller-workspace split) id from a
  * persisted spawn manifest, if any. Returns undefined when the manifest
  * is missing, malformed, or has no aux surface — caller treats those
@@ -210,7 +226,7 @@ export class Orchestrator {
     const envExports = `export ${Object.entries(opts.env)
       .map(([k, v]) => `${k}=${shellEscape(v)}`)
       .join(" ")}`;
-    const fullCommand = `cd ${shellEscape(projectDir)} && ${envExports} && ${command}`;
+    const fullCommand = `cd ${shellEscape(projectDir)} && ${envExports} && ${SOURCE_NEAREST_ENV} && ${command}`;
 
     // Create screen session
     const session = await screen.createSession(screenName, fullCommand);
@@ -443,7 +459,7 @@ export class Orchestrator {
     const envExports = `export ${Object.entries(mergedEnv)
       .map(([k, v]) => `${k}=${shellEscape(v)}`)
       .join(" ")}`;
-    const fullCommand = `cd ${shellEscape(projectDir)} && ${envExports} && ${command}`;
+    const fullCommand = `cd ${shellEscape(projectDir)} && ${envExports} && ${SOURCE_NEAREST_ENV} && ${command}`;
 
     const session = await screen.createSession(screenName, fullCommand);
 


### PR DESCRIPTION
## Why

Step 1 of retiring `~/.wire/cc-launch.sh` (Tim: GO, 2026-06-05). The script's only remaining job is sourcing the nearest project `.env` so `.mcp.json` MCP servers that interpolate `${VAR}`s see real values (the non-interactive spawn shell never fires direnv). That belongs in the orchestrator, not a standalone untracked launcher script — the gap that hid the root-discovery bug.

## What

Both command builders (`launchAgent` + `resumeAgent`) now emit
`cd <projectDir> && <envExports> && <source-nearest-.env> && <command>` — the sourcing snippet ported verbatim from cc-launch.sh (walk up to the first `.env`, `set -a` source). Ordering preserves its semantics exactly: a `.env` value wins a collision with the forwarded env map. Runtime-agnostic; codex-launch.sh double-sourcing is an idempotent re-export.

## Tests

4 new — command-shape assertions for launch + resume, plus two REAL-shell executions of the snippet (nearest `.env` wins and exports; no `.env` up the tree is a clean no-op). Suite 37/37.

## Not in this PR (gated follow-ups)

Re-pin cascade (crew-cc, bridge-tools, bridge-cc) → adoption → throwaway-spawn FV (.env vars present in a real spawned agent) → THEN flip `~/.wire/runtimes.json` to plain `claude` and delete cc-launch.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)