### PR TITLE
launch/resume: verify the dev-channel confirm actually landed (v2.16.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/crew-tools",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "Agent crew orchestration primitives \u2014 screen sessions, iTerm2 panes, SQLite state, runtime-agnostic.",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/orchestrator.test.ts
+++ b/src/orchestrator.test.ts
@@ -8,7 +8,19 @@ import type { TerminalBackend } from "./terminal";
 // Capture the command passed to screen.createSession so we can assert on the
 // spawn-time env exports. Mock is installed before Orchestrator is imported.
 const createSessionCalls: Array<{ name: string; command: string }> = [];
-const screenState = { isAliveResult: false, isAttachedResult: false };
+const screenState = {
+  isAliveResult: false,
+  isAttachedResult: false,
+  // Scriptable screen content, KEYED BY SCREEN NAME so tests can't bleed
+  // into the background auto-confirm loops of agents launched by other
+  // tests (those poll their own wire-<id> screens, which stay blank).
+  // Reads pop the named queue, then fall back to the named default.
+  // sendKeys appends to the log and fires the optional hook so a test
+  // can flip screen content in reaction to a CR.
+  screens: {} as Record<string, { queue: string[]; fallback: string }>,
+  sendKeysLog: [] as Array<{ name: string; keys: string }>,
+  sendKeysHook: null as ((name: string, keys: string) => void) | null,
+};
 mock.module("./screen", () => ({
   createSession: async (name: string, command: string) => {
     createSessionCalls.push({ name, command });
@@ -19,12 +31,19 @@ mock.module("./screen", () => ({
   isAlive: async () => screenState.isAliveResult,
   isAttached: async () => screenState.isAttachedResult,
   detachSession: async () => {},
-  sendKeys: async () => {},
-  readOutput: async () => "",
+  sendKeys: async (name: string, keys: string) => {
+    screenState.sendKeysLog.push({ name, keys });
+    screenState.sendKeysHook?.(name, keys);
+  },
+  readOutput: async (name: string) => {
+    const s = screenState.screens[name];
+    if (!s) return "";
+    return s.queue.length > 0 ? s.queue.shift()! : s.fallback;
+  },
   killSession: async () => {},
 }));
 
-const { Orchestrator, SOURCE_NEAREST_ENV } = await import("./orchestrator");
+const { Orchestrator, SOURCE_NEAREST_ENV, autoConfirmDevChannel } = await import("./orchestrator");
 
 function makeTerminal(): TerminalBackend {
   return {
@@ -58,6 +77,9 @@ beforeEach(() => {
   dbPath = join(tmpDir, "test.db");
   orch = new Orchestrator(makeTerminal(), dbPath);
   createSessionCalls.length = 0;
+  screenState.screens = {};
+  screenState.sendKeysLog.length = 0;
+  screenState.sendKeysHook = null;
 });
 
 afterAll(() => {
@@ -586,5 +608,79 @@ describe("nearest-ancestor .env sourcing (cc-launch.sh fold)", () => {
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+describe("autoConfirmDevChannel — verify-after-confirm", () => {
+  const MARKER_SCREEN = "Development channels can run arbitrary code.\n  Enter to confirm · Esc to reject";
+  const BOOTED_SCREEN = "❯ \n  ⏵⏵ bypass permissions on (shift+tab to cycle) · ? for shortcuts";
+  const crs = () => screenState.sendKeysLog.filter((e) => e.name === "dvc" && e.keys === "\r").length;
+
+  test("confirms the prompt and verifies it cleared", async () => {
+    screenState.screens["dvc"] = { queue: ["starting claude…", MARKER_SCREEN], fallback: BOOTED_SCREEN };
+
+    const ok = await autoConfirmDevChannel("dvc", "t1", { appearMs: 2_000, clearMs: 1_000 });
+
+    expect(ok).toBe(true);
+    expect(crs()).toBe(1);
+  });
+
+  test("retries the CR when the prompt does not clear, then succeeds", async () => {
+    screenState.screens["dvc"] = { queue: [], fallback: MARKER_SCREEN };
+    screenState.sendKeysHook = (name, keys) => {
+      // First CR is "lost" (screen keeps showing the prompt); the second lands.
+      if (name === "dvc" && keys === "\r" && crs() >= 2) {
+        screenState.screens["dvc"]!.fallback = BOOTED_SCREEN;
+      }
+    };
+
+    const ok = await autoConfirmDevChannel("dvc", "t2", { appearMs: 2_000, clearMs: 400 });
+
+    expect(ok).toBe(true);
+    expect(crs()).toBe(2);
+  });
+
+  test("normal input UI with no prompt = nothing to confirm, no keys sent", async () => {
+    screenState.screens["dvc"] = { queue: [], fallback: BOOTED_SCREEN };
+
+    const ok = await autoConfirmDevChannel("dvc", "t3", { appearMs: 2_000 });
+
+    expect(ok).toBe(true);
+    expect(crs()).toBe(0);
+  });
+
+  test("nothing renders → false + loud status on the agent row", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "halfboot" } });
+    // "dvc" stays blank forever (no screens entry → reads return "").
+
+    const ok = await autoConfirmDevChannel("dvc", "halfboot", {
+      store: orch.store,
+      agentId: "halfboot",
+      appearMs: 400,
+      clearMs: 200,
+    });
+
+    expect(ok).toBe(false);
+    const row = orch.store.getAgent("halfboot");
+    expect(row?.status_name).toBe("dev-channel-confirm-failed");
+    expect(row?.status_desc).toContain("nothing will confirm it");
+  });
+
+  test("prompt stuck through all retries → false + status records the stuck prompt", async () => {
+    await orch.launchAgent({ env: { AGENT_ID: "stuckboot" } });
+    screenState.screens["dvc"] = { queue: [], fallback: MARKER_SCREEN };
+
+    const ok = await autoConfirmDevChannel("dvc", "stuckboot", {
+      store: orch.store,
+      agentId: "stuckboot",
+      appearMs: 2_000,
+      clearMs: 300,
+    });
+
+    expect(ok).toBe(false);
+    expect(crs()).toBe(3);
+    const row = orch.store.getAgent("stuckboot");
+    expect(row?.status_name).toBe("dev-channel-confirm-failed");
+    expect(row?.status_desc).toContain("did not clear after 3 CR attempts");
   });
 });

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -96,32 +96,85 @@ function readAuxSurface(spawnManifest: string | null): string | undefined {
 }
 
 /**
- * Auto-confirm Claude's dev-channel prompt by polling the screen buffer
- * for the prompt marker, then sending CR. Fire-and-forget; bounded by a
- * 30s deadline. Replaces the prior fixed-3s setTimeout which raced
- * Claude's startup time (the typical case on cold caches: claude takes
- * >3s to render the prompt, the CR lands in a still-starting shell, and
- * the agent stays stuck on the prompt forever).
+ * Auto-confirm Claude's dev-channel prompt and VERIFY the confirm landed.
+ *
+ * Polls the screen buffer for the prompt marker, sends CR, then polls
+ * again until the marker CLEARS — retrying the CR if it didn't. A
+ * fire-and-forget CR can miss (screen still initializing, prompt redraw
+ * race), and under boot-storm load the prompt can take >30s to render at
+ * all; either way the dev-channel plugin silently never loads and the
+ * agent runs half-booted — e.g. Wire-blind: registered on the broker
+ * with no client behind it (canele-2947, 2026-06-10, cost a day of
+ * messaging). Polling beats setTimeout because boot time varies with
+ * machine load; verifying beats trusting because sendKeys has no
+ * delivery receipt.
+ *
+ * Resolution states:
+ *  - marker seen, CR confirmed cleared        → true (confirmed)
+ *  - normal input UI rendered with no marker  → true (no prompt this boot)
+ *  - marker stuck through CR retries, or
+ *    nothing rendered within the window       → false + LOUD persistent
+ *    status on the agent row (status_name="dev-channel-confirm-failed")
+ *    so the half-boot is visible to operators and orchestrators instead
+ *    of being discovered by silence.
  */
-async function autoConfirmDevChannel(screenName: string, label: string): Promise<void> {
+export async function autoConfirmDevChannel(
+  screenName: string,
+  label: string,
+  opts: { store?: CrewStore; agentId?: string; appearMs?: number; clearMs?: number } = {},
+): Promise<boolean> {
   const marker = "Enter to confirm";
-  const deadline = Date.now() + 30_000;
-  while (Date.now() < deadline) {
+  // CC renders its normal input UI only after the dev-channel gate, so
+  // either footer hint appearing without the marker means no prompt is
+  // coming this boot.
+  const bootedWithoutPrompt = (buf: string) =>
+    !buf.includes(marker) && (buf.includes("? for shortcuts") || buf.includes("⏵⏵"));
+  const appearDeadline = Date.now() + (opts.appearMs ?? 120_000);
+
+  let seen = false;
+  while (Date.now() < appearDeadline) {
     try {
       const buf = await screen.readOutput(screenName);
-      if (buf.includes(marker)) {
-        await screen.sendKeys(screenName, "\r");
-        return;
-      }
+      if (buf.includes(marker)) { seen = true; break; }
+      if (bootedWithoutPrompt(buf)) return true;
     } catch {
       // screen may be momentarily unavailable during startup; retry
     }
     await new Promise((r) => setTimeout(r, 250));
   }
-  console.warn(
-    `[crew] dev-channel auto-confirm timed out for ${label} ` +
-    `(marker '${marker}' not seen in 30s)`,
-  );
+
+  if (seen) {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        await screen.sendKeys(screenName, "\r");
+      } catch {
+        // transient send failure — the clear-poll below times out and we retry
+      }
+      const clearDeadline = Date.now() + (opts.clearMs ?? 5_000);
+      while (Date.now() < clearDeadline) {
+        await new Promise((r) => setTimeout(r, 250));
+        try {
+          const buf = await screen.readOutput(screenName);
+          if (!buf.includes(marker)) return true;
+        } catch {
+          // transient read failure; keep polling
+        }
+      }
+    }
+  }
+
+  const detail = seen
+    ? `dev-channel prompt did not clear after 3 CR attempts on ${screenName}`
+    : `neither dev-channel prompt nor input UI rendered within the window on ${screenName} — if the prompt shows later, nothing will confirm it`;
+  console.warn(`[crew] dev-channel auto-confirm FAILED for ${label}: ${detail}`);
+  if (opts.store && opts.agentId) {
+    try {
+      opts.store.updateAgentStatus(opts.agentId, "dev-channel-confirm-failed", detail);
+    } catch {
+      // status write is best-effort; the warn above already fired
+    }
+  }
+  return false;
 }
 
 export class Orchestrator {
@@ -234,7 +287,7 @@ export class Orchestrator {
     // Auto-confirm the dev-channel prompt. Fire-and-forget — helper polls
     // the screen buffer until the prompt marker appears, then sends CR.
     // See autoConfirmDevChannel comment for why polling beats setTimeout.
-    void autoConfirmDevChannel(screenName, id);
+    void autoConfirmDevChannel(screenName, id, { store: this.store, agentId: id });
 
     // Best-effort: if the caller asked to be split next to the new agent,
     // and the backend supports per-caller splits (cmux today, iTerm2
@@ -464,7 +517,7 @@ export class Orchestrator {
     const session = await screen.createSession(screenName, fullCommand);
 
     // Auto-confirm dev-channel prompt — same polling helper as launchAgent.
-    void autoConfirmDevChannel(screenName, `resumed ${opts.id}`);
+    void autoConfirmDevChannel(screenName, `resumed ${opts.id}`, { store: this.store, agentId: opts.id });
 
     // Write a fresh manifest for the resumed agent so it can be resumed
     // again later. Channels flow into the manifest only here (launchAgent


### PR DESCRIPTION
autoConfirmDevChannel was fire-and-forget: poll 30s for the prompt,
send one CR, return without checking it cleared. Two silent failure
modes: the CR misses (screen init race) or the prompt renders after
the window under boot-storm load — either way the dev-channel plugin
never loads and the agent runs half-booted, e.g. Wire-blind:
registered on the broker with no client behind it (canele-2947,
2026-06-10 — burned a day of messaging).

Now: 120s window; after CR, poll until the marker CLEARS, retrying the
CR up to 3 times; a normal input UI rendering without the marker
counts as no-prompt-this-boot (no false alarms); persistent failure
writes status_name='dev-channel-confirm-failed' onto the agent row so
operators and orchestrators see the half-boot instead of discovering
it by silence.

5 new tests (confirm+verify, lost-CR retry, no-prompt boot, blank
screen, stuck prompt); screen mock now keyed by session name so
background confirm loops from other tests can't bleed in. 42/42 in
orchestrator suite; full suite green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
